### PR TITLE
feat(encyclopedia): add encyclopedia detail page

### DIFF
--- a/src/app/ensiklopedia/[slug]/page.tsx
+++ b/src/app/ensiklopedia/[slug]/page.tsx
@@ -1,0 +1,26 @@
+import { getEncyclopediaArticleDetail } from '@/components/ensiklopedia/constants';
+import { EncyclopediaDetailMain } from '@/components/ensiklopedia/encyclopedia-detail-main';
+import { Footer } from '@/components/footer';
+import { Header } from '@/components/header';
+import { notFound } from 'next/navigation';
+
+type Props = {
+  params: Promise<{ slug: string }>;
+};
+
+export default async function EncyclopediaDetailPage({ params }: Props) {
+  const { slug } = await params;
+  const article = getEncyclopediaArticleDetail(slug);
+
+  if (!article) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-[#f5f3ec] text-[#2d4f3f]">
+      <Header homeHref="/" />
+      <EncyclopediaDetailMain article={article} />
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/ensiklopedia/constants.ts
+++ b/src/components/ensiklopedia/constants.ts
@@ -3,6 +3,9 @@
  */
 import type {
   EncyclopediaArticle,
+  EncyclopediaArticleDetail,
+  EncyclopediaKeyFact,
+  EncyclopediaSection,
   RegionFilter,
   Stat,
 } from '@/types/encyclopedia';
@@ -36,6 +39,7 @@ export const ENCYCLOPEDIA_TOPICS: string[] = [
 
 export const ENCYCLOPEDIA_ARTICLES: EncyclopediaArticle[] = [
   {
+    slug: 'sejarah-batik-jawa-warisan-dunia-unesco',
     region: 'Jawa',
     topic: 'Sejarah & Asal Usul',
     motifLabel: 'Batik',
@@ -48,6 +52,7 @@ export const ENCYCLOPEDIA_ARTICLES: EncyclopediaArticle[] = [
     featured: true,
   },
   {
+    slug: 'tenun-ikat-teknik-kuno-dari-kepulauan-nusantara',
     region: 'Nusa Tenggara',
     topic: 'Teknik Pembuatan',
     motifLabel: 'Ikat',
@@ -58,6 +63,7 @@ export const ENCYCLOPEDIA_ARTICLES: EncyclopediaArticle[] = [
     views: '1,550',
   },
   {
+    slug: 'songket-kain-kebesaran-kerajaan-melayu',
     region: 'Sumatra',
     topic: 'Sejarah & Asal Usul',
     motifLabel: 'Ikat',
@@ -68,6 +74,7 @@ export const ENCYCLOPEDIA_ARTICLES: EncyclopediaArticle[] = [
     views: '1,240',
   },
   {
+    slug: 'kebaya-identitas-perempuan-nusantara',
     region: 'Jawa',
     topic: 'Motif & Simbolisme',
     motifLabel: 'Ikat',
@@ -78,6 +85,7 @@ export const ENCYCLOPEDIA_ARTICLES: EncyclopediaArticle[] = [
     views: '870',
   },
   {
+    slug: 'ulos-batak-kain-adat-penuh-makna-spiritual',
     region: 'Sumatra',
     topic: 'Upacara Adat',
     motifLabel: 'Ulos',
@@ -88,6 +96,7 @@ export const ENCYCLOPEDIA_ARTICLES: EncyclopediaArticle[] = [
     views: '870',
   },
   {
+    slug: 'lurik-kain-garis-penjaga-tradisi-jawa',
     region: 'Jawa',
     topic: 'Teknik Pembuatan',
     motifLabel: 'Lurik',
@@ -98,6 +107,7 @@ export const ENCYCLOPEDIA_ARTICLES: EncyclopediaArticle[] = [
     views: '870',
   },
   {
+    slug: 'gringsing-tenganan-double-ikat-tersulit-di-dunia',
     region: 'Bali',
     topic: 'Teknik Pembuatan',
     motifLabel: 'Gringsing',
@@ -108,6 +118,7 @@ export const ENCYCLOPEDIA_ARTICLES: EncyclopediaArticle[] = [
     views: '870',
   },
   {
+    slug: 'ragam-wastra-nusantara-dari-sabang-sampai-merauke',
     region: 'Kalimantan',
     topic: 'Sejarah & Asal Usul',
     motifLabel: 'Indonesian textiles',
@@ -118,6 +129,7 @@ export const ENCYCLOPEDIA_ARTICLES: EncyclopediaArticle[] = [
     views: '870',
   },
   {
+    slug: 'filosofi-motif-batik-keraton-yogyakarta',
     region: 'Jawa',
     topic: 'Motif & Simbolisme',
     motifLabel: 'Batik',
@@ -128,6 +140,7 @@ export const ENCYCLOPEDIA_ARTICLES: EncyclopediaArticle[] = [
     views: '870',
   },
   {
+    slug: 'tenun-sumba-kosmologi-dalam-helai-kain',
     region: 'Nusa Tenggara',
     topic: 'Motif & Simbolisme',
     motifLabel: 'Ikat',
@@ -138,6 +151,7 @@ export const ENCYCLOPEDIA_ARTICLES: EncyclopediaArticle[] = [
     views: '870',
   },
   {
+    slug: 'upacara-mangulosi-pemberian-ulos-dalam-adat-batak',
     region: 'Sumatra',
     topic: 'Upacara Adat',
     motifLabel: 'Ikat',
@@ -148,6 +162,7 @@ export const ENCYCLOPEDIA_ARTICLES: EncyclopediaArticle[] = [
     views: '870',
   },
   {
+    slug: 'songket-minangkabau-emas-dalam-tenunan',
     region: 'Sumatra',
     topic: 'Pengrajin Lokal',
     motifLabel: 'Ikat',
@@ -158,3 +173,170 @@ export const ENCYCLOPEDIA_ARTICLES: EncyclopediaArticle[] = [
     views: '870',
   },
 ];
+
+const DEFAULT_REFERENCES = [
+  '[1] Wikipedia - Batik',
+  '[2] Direktorat Warisan dan Diplomasi Budaya, Kemendikbud RI',
+  '[3] Dekranasda Provinsi Jawa Tengah',
+];
+
+const buildDefaultSections = (
+  article: EncyclopediaArticle,
+): EncyclopediaSection[] => [
+  {
+    title: `Asal Usul ${article.motifLabel}`,
+    content:
+      `${article.motifLabel} memiliki jejak sejarah panjang dalam tradisi wastra Indonesia. ` +
+      `Di banyak wilayah, kain ini berkembang dari fungsi ritual menjadi identitas budaya ` +
+      `yang diwariskan lintas generasi melalui praktik menenun, membatik, atau menyungkit.`,
+  },
+  {
+    title: `Makna dan Nilai Budaya ${article.motifLabel}`,
+    content:
+      `Setiap pola, warna, dan teknik pada ${article.motifLabel} memuat nilai sosial serta filosofi ` +
+      `lokal. Dalam konteks adat, kain tidak sekadar benda pakai, tetapi juga simbol status, ` +
+      `doa, dan penghormatan pada leluhur.`,
+  },
+  {
+    title: `Tantangan Pelestarian ${article.motifLabel}`,
+    content:
+      `Perubahan pasar dan regenerasi pengrajin menjadi tantangan utama. Upaya dokumentasi, ` +
+      `kolaborasi desain, dan edukasi publik menjadi strategi penting agar wastra tetap relevan ` +
+      `tanpa kehilangan nilai tradisinya.`,
+  },
+];
+
+const buildDefaultKeyFacts = (
+  article: EncyclopediaArticle,
+): EncyclopediaKeyFact[] => [
+  { label: 'Wilayah Utama', value: article.region },
+  { label: 'Kategori', value: article.topic },
+  { label: 'Jenis Wastra', value: article.motifLabel },
+  { label: 'Durasi Baca', value: `${article.readMinutes ?? 6} menit` },
+  { label: 'Dilihat', value: `${article.views} kali` },
+  { label: 'Disukai', value: `${article.likes} pengguna` },
+];
+
+const DETAIL_OVERRIDES: Partial<
+  Record<string, Partial<EncyclopediaArticleDetail>>
+> = {
+  'sejarah-batik-jawa-warisan-dunia-unesco': {
+    author: 'Admin',
+    publishedAt: '10 Mar 2025',
+    tags: ['Batik', 'UNESCO', 'Jawa', 'Sejarah', 'Keraton'],
+    quote:
+      'Batik adalah teknik seni pewarnaan kain menggunakan malam sebagai perintang warna. Pada 2 Oktober 2009, UNESCO menetapkan Batik Indonesia sebagai Warisan Budaya Takbenda Kemanusiaan.',
+    intro:
+      'Batik is a dyeing technique using wax resist. The term is also used to describe patterned textiles created with that technique. Batik is made by drawing or stamping wax on a cloth to prevent colour absorption during the dyeing process.',
+    sections: [
+      {
+        title: 'Asal Usul Batik di Nusantara',
+        content:
+          'Sejarah batik di Indonesia dapat ditelusuri hingga abad ke-12 pada masa Kerajaan Mataram Hindu. Batik yang kita kenal sekarang berkembang pesat pada era Kesultanan Mataram Islam abad ke-17 di lingkungan keraton Surakarta dan Yogyakarta.',
+        imageLabel: 'Batik',
+        imageCaption: 'Gambar: Batik - sumber Wikipedia / Wikimedia Commons',
+      },
+      {
+        title: 'Filosofi Motif dan Makna Simbolis',
+        content:
+          'Setiap motif batik keraton menyimpan makna filosofis yang dalam. Motif Kawung melambangkan kemurnian dan harapan. Motif Parang Rusak melambangkan kekuatan ksatria. Filosofi Jawa yang kaya tercuang dalam setiap garis dan titik kain batik.',
+      },
+      {
+        title: 'Perbedaan Batik Tulis, Cap, dan Printing',
+        content:
+          'Batik tulis adalah yang paling tinggi nilainya karena dibuat manual menggunakan canting. Batik cap menggunakan cap tembaga sehingga produksi lebih cepat namun tetap autentik. Batik printing menggunakan teknik cetak industri untuk produksi massal.',
+      },
+      {
+        title: 'Batik di Era Modern dan Diplomasi Budaya',
+        content:
+          'Pada era modern, batik digunakan sebagai busana formal nasional hingga koleksi mode kontemporer. Tren ini diperkuat diplomasi budaya Indonesia di forum internasional dan ajang fashion global.',
+        imageLabel: 'Batik',
+        imageCaption: 'Gambar: Batik - sumber Wikipedia / Wikimedia Commons',
+      },
+      {
+        title: 'Tantangan Pelestarian dan Peluang Masa Depan',
+        content:
+          'Regenerasi pengrajin, kenaikan bahan baku, dan kompetisi produk murah menjadi tantangan utama. Namun teknologi digital membuka peluang baru: platform marketplace, workshop daring, serta dokumentasi karya berbasis arsip terbuka.',
+      },
+    ],
+    keyFacts: [
+      { label: 'Ditetapkan UNESCO', value: '2 Oktober 2009' },
+      { label: 'Asal Tertua', value: 'Kerajaan Mataram, abad ke-12' },
+      { label: 'Pusat Produksi', value: 'Solo, Yogyakarta, Pekalongan' },
+      { label: 'Jumlah Pengrajin', value: '± 50.000 pengrajin aktif' },
+      { label: 'Nilai Ekspor', value: 'Rp 1,2 triliun/tahun' },
+      { label: 'Teknik Utama', value: 'Tulis, Cap, Printing' },
+    ],
+    relatedProducts: [
+      {
+        name: 'Batik Tulis Kawung',
+        location: 'Solo, Jawa Tengah',
+        price: 'Rp 350.000',
+      },
+      {
+        name: 'Batik Cap Mega Mendung',
+        location: 'Cirebon, Jawa Barat',
+        price: 'Rp 250.000',
+      },
+    ],
+    discussionCount: 8,
+    references: [
+      '[1] Wikipedia - Batik (en.wikipedia.org)',
+      '[2] Direktorat Warisan dan Diplomasi Budaya, Kemendikbud RI',
+      '[3] Dekranasda Provinsi Jawa Tengah',
+      '[4] Jurnal Wastra Nusantara, Vol. 12, 2024',
+      '[5] Dr. Nadia Kusumawardhani - Laporan Penelitian Lapangan 2023',
+    ],
+  },
+};
+
+export const getEncyclopediaArticleBySlug = (slug: string) =>
+  ENCYCLOPEDIA_ARTICLES.find((article) => article.slug === slug) ?? null;
+
+export const getEncyclopediaArticleDetail = (
+  slug: string,
+): EncyclopediaArticleDetail | null => {
+  const articleIndex = ENCYCLOPEDIA_ARTICLES.findIndex(
+    (article) => article.slug === slug,
+  );
+
+  if (articleIndex === -1) {
+    return null;
+  }
+
+  const article = ENCYCLOPEDIA_ARTICLES[articleIndex];
+  const nextArticle =
+    ENCYCLOPEDIA_ARTICLES[(articleIndex + 1) % ENCYCLOPEDIA_ARTICLES.length];
+  const override = DETAIL_OVERRIDES[slug] ?? {};
+
+  return {
+    ...article,
+    author: override.author ?? 'Admin',
+    publishedAt: override.publishedAt ?? '10 Mar 2025',
+    tags: override.tags ?? [article.motifLabel, article.region, article.topic],
+    quote:
+      override.quote ??
+      `${article.motifLabel} merepresentasikan warisan budaya yang hidup melalui teknik, simbol, dan praktik sosial masyarakat Indonesia.`,
+    intro: override.intro ?? article.excerpt,
+    sections: override.sections ?? buildDefaultSections(article),
+    keyFacts: override.keyFacts ?? buildDefaultKeyFacts(article),
+    relatedProducts: override.relatedProducts ?? [
+      {
+        name: 'Batik Tulis Kawung',
+        location: 'Solo, Jawa Tengah',
+        price: 'Rp 350.000',
+      },
+      {
+        name: 'Tenun Ikat Flores',
+        location: 'Flores, NTT',
+        price: 'Rp 580.000',
+      },
+    ],
+    discussionCount: override.discussionCount ?? 8,
+    nextArticle: override.nextArticle ?? {
+      slug: nextArticle.slug,
+      title: nextArticle.title,
+    },
+    references: override.references ?? DEFAULT_REFERENCES,
+  };
+};

--- a/src/components/ensiklopedia/encyclopedia-detail-main.tsx
+++ b/src/components/ensiklopedia/encyclopedia-detail-main.tsx
@@ -1,0 +1,298 @@
+import { Badge } from '@/components/ui/badge';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import type { EncyclopediaArticleDetail } from '@/types/encyclopedia';
+import {
+  CalendarDays,
+  ChevronRight,
+  Clock3,
+  Eye,
+  Heart,
+  MessageCircle,
+  Quote,
+  UserRound,
+} from 'lucide-react';
+import Link from 'next/link';
+
+type EncyclopediaDetailMainProps = {
+  article: EncyclopediaArticleDetail;
+};
+
+export function EncyclopediaDetailMain({
+  article,
+}: EncyclopediaDetailMainProps) {
+  return (
+    <main className="mx-auto w-full max-w-[1320px] px-4 pb-14 pt-6 md:px-6 lg:px-8">
+      <Breadcrumb>
+        <BreadcrumbList className="text-sm font-medium text-[#6e8276]">
+          <BreadcrumbItem>
+            <BreadcrumbLink href="/" className="hover:text-[#2f5b49]">
+              Beranda
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink
+              href="/ensiklopedia"
+              className="hover:text-[#2f5b49]"
+            >
+              Ensiklopedia Budaya
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage className="line-clamp-1 max-w-[280px] text-[#2f5b49]">
+              {article.title}
+            </BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <section className="mt-4 overflow-hidden rounded-2xl border border-[#dacfbf] bg-[#ece1d0]">
+        <div className="relative min-h-[340px] border-b border-dashed border-[#d8ccbb]">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_52%_22%,rgba(242,229,205,0.9)_0%,rgba(218,202,178,0.72)_42%,rgba(154,133,108,0.88)_100%)]" />
+          <div className="absolute inset-0 bg-gradient-to-t from-[#4a3c2f]/90 via-[#5a4a3a]/25 to-transparent" />
+
+          <div className="absolute inset-0 grid place-items-center">
+            <div className="flex flex-col items-center gap-2 text-[#5f503e]">
+              <span className="h-5 w-5 rotate-45 border border-[#ccbda4]" />
+              <span className="text-sm font-medium">{article.motifLabel}</span>
+            </div>
+          </div>
+
+          <div className="absolute inset-x-0 bottom-0 p-5 md:p-6">
+            <div className="mb-3 flex flex-wrap gap-2">
+              <Badge className="rounded bg-[#efe2d8] px-2 py-1 text-[11px] text-[#c17f61] hover:bg-[#efe2d8]">
+                {article.topic}
+              </Badge>
+              <Badge className="rounded bg-[#ece6d9] px-2 py-1 text-[11px] text-[#b39f86] hover:bg-[#ece6d9]">
+                {article.region}
+              </Badge>
+            </div>
+
+            <h1 className="max-w-4xl text-3xl font-bold tracking-tight text-[#f8f3e8] md:text-5xl">
+              {article.title}
+            </h1>
+
+            <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-[#ded4c4]">
+              <span className="inline-flex items-center gap-1.5">
+                <UserRound className="h-3.5 w-3.5" />
+                {article.author}
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <CalendarDays className="h-3.5 w-3.5" />
+                {article.publishedAt}
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <Clock3 className="h-3.5 w-3.5" />
+                {article.readMinutes ?? 8} menit baca
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <Eye className="h-3.5 w-3.5" />
+                {article.views} ditonton
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3 bg-[#f4efe5] p-4">
+          <div className="flex flex-wrap gap-2">
+            {article.tags.map((tag) => (
+              <Badge
+                key={tag}
+                variant="outline"
+                className="rounded-full border-[#e0d6c5] bg-[#efe8dc] px-2.5 py-0.5 text-xs font-semibold text-[#b48464] hover:bg-[#e9e1d2]"
+              >
+                {tag}
+              </Badge>
+            ))}
+          </div>
+
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="h-8 w-8 rounded-full border-[#d8cfbe] text-[#7f7467] hover:text-[#2f5f49]"
+          >
+            <Heart className="h-4 w-4" />
+          </Button>
+        </div>
+      </section>
+
+      <section className="mt-6 grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px]">
+        <article>
+          <Card className="rounded-xl border border-[#e1d8c9] bg-[#f8f3ea] p-4">
+            <p className="inline-flex items-start gap-2 text-sm leading-relaxed text-[#5f6c63] italic">
+              <Quote className="mt-0.5 h-4 w-4 shrink-0 text-[#97a694]" />
+              {article.quote}
+            </p>
+          </Card>
+
+          <p className="mt-6 text-[15px] leading-8 text-[#3d5449]">
+            {article.intro}
+          </p>
+
+          {article.sections.map((section, index) => {
+            const showVisual = Boolean(section.imageCaption);
+
+            return (
+              <section key={section.title} className="mt-9">
+                <h2 className="text-4xl font-bold tracking-tight text-[#2f5b49]">
+                  {section.title}
+                </h2>
+
+                <div
+                  className={
+                    showVisual
+                      ? 'mt-3 grid gap-5 md:grid-cols-[minmax(0,1fr)_260px]'
+                      : 'mt-3'
+                  }
+                >
+                  <p className="text-[15px] leading-8 text-[#465d51]">
+                    {section.content}
+                  </p>
+
+                  {showVisual ? (
+                    <Card className="overflow-hidden rounded-xl border border-[#dfd4c2] bg-[#f5f1e8]">
+                      <div className="relative min-h-[200px] border-b border-dashed border-[#d9cebc] bg-[#ece1d0]">
+                        <div className="absolute inset-0 grid place-items-center">
+                          <div className="flex flex-col items-center gap-2 text-[#6f604e]">
+                            <span className="h-4 w-4 rotate-45 border border-[#ccbda4]" />
+                            <span className="text-sm font-medium">
+                              {section.imageLabel ?? article.motifLabel}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+
+                      <p className="px-3 py-2 text-xs text-[#5b5f59]">
+                        {section.imageCaption}
+                      </p>
+                    </Card>
+                  ) : null}
+                </div>
+
+                {index < article.sections.length - 1 ? (
+                  <Separator className="mt-7 bg-[#ddd4c4]" />
+                ) : null}
+              </section>
+            );
+          })}
+
+          <Card className="mt-10 rounded-xl border border-[#ddd2c0] bg-[#f7f3e9] p-5">
+            <h3 className="text-lg font-bold text-[#355645]">
+              Sumber & Referensi
+            </h3>
+            <div className="mt-3 space-y-1.5 text-sm leading-7 text-[#5c6b62]">
+              {article.references.map((reference) => (
+                <p key={reference}>{reference}</p>
+              ))}
+            </div>
+          </Card>
+        </article>
+
+        <aside className="space-y-4">
+          <Card className="overflow-hidden rounded-xl border border-[#ddd2bf] bg-[#f7f3ea]">
+            <div className="bg-[#2f5f49] px-4 py-2">
+              <h3 className="text-sm font-bold text-[#eef3eb]">Fakta Kunci</h3>
+            </div>
+
+            <div className="divide-y divide-[#e6ddd0]">
+              {article.keyFacts.map((fact) => (
+                <div
+                  key={fact.label}
+                  className="grid grid-cols-[120px_minmax(0,1fr)] gap-2 px-4 py-2.5 text-xs"
+                >
+                  <span className="text-[#536a5e]">{fact.label}</span>
+                  <span className="font-semibold text-[#2f4f40]">
+                    {fact.value}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </Card>
+
+          <Card className="rounded-xl border border-[#ddd2bf] bg-[#f7f3ea] p-4">
+            <div className="mb-3 flex items-center justify-between">
+              <h3 className="text-sm font-bold text-[#355645]">
+                Produk Terkait
+              </h3>
+              <Button
+                variant="link"
+                className="h-auto p-0 text-xs text-[#c17f61]"
+              >
+                Lihat semua
+              </Button>
+            </div>
+
+            <div className="space-y-3">
+              {article.relatedProducts.map((product) => (
+                <div key={product.name}>
+                  <p className="text-sm font-semibold text-[#365746]">
+                    {product.name}
+                  </p>
+                  <p className="text-xs text-[#7d7a70]">{product.location}</p>
+                  <p className="text-sm font-bold text-[#2f5f49]">
+                    {product.price}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </Card>
+
+          <Card className="rounded-xl border border-[#ddd2bf] bg-[#f7f3ea] p-4">
+            <h3 className="text-sm font-bold text-[#355645]">
+              Statistik Artikel
+            </h3>
+
+            <div className="mt-3 grid grid-cols-2 gap-2">
+              <div className="rounded-md border border-[#e4dbcd] bg-[#f1ebdf] p-2 text-center">
+                <p className="text-lg font-bold text-[#2f5f49]">
+                  {article.views}
+                </p>
+                <p className="text-[11px] text-[#677a6e]">Kunjungan</p>
+              </div>
+              <div className="rounded-md border border-[#e4dbcd] bg-[#f1ebdf] p-2 text-center">
+                <p className="text-lg font-bold text-[#2f5f49]">
+                  {article.discussionCount}
+                </p>
+                <p className="text-[11px] text-[#677a6e]">Diskusi</p>
+              </div>
+            </div>
+          </Card>
+
+          <Card className="rounded-xl border border-[#ddd2bf] bg-[#f7f3ea] p-4">
+            <h3 className="text-sm font-bold text-[#355645]">
+              Navigasi Artikel
+            </h3>
+            <Button
+              asChild
+              className="mt-3 w-full justify-between rounded-md bg-[#ece5d9] px-3 py-2 text-sm text-[#385847] hover:bg-[#e3dbc9]"
+            >
+              <Link href={`/ensiklopedia/${article.nextArticle.slug}`}>
+                <span className="line-clamp-1 text-left">
+                  {article.nextArticle.title}
+                </span>
+                <ChevronRight className="h-4 w-4" />
+              </Link>
+            </Button>
+
+            <div className="mt-2 inline-flex items-center gap-1 text-xs text-[#6f7a73]">
+              <MessageCircle className="h-3.5 w-3.5" />
+              Lanjutkan baca artikel terkait
+            </div>
+          </Card>
+        </aside>
+      </section>
+    </main>
+  );
+}

--- a/src/components/ensiklopedia/encyclopedia-main.tsx
+++ b/src/components/ensiklopedia/encyclopedia-main.tsx
@@ -25,9 +25,11 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 export function EncyclopediaMain() {
+  const router = useRouter();
   const [currentView, setCurrentView] = useState<ViewMode>('grid');
   const [currentPage, setCurrentPage] = useState(1);
   const totalPages = 12;
@@ -66,8 +68,7 @@ export function EncyclopediaMain() {
   };
 
   const handleArticleClick = (article: EncyclopediaArticle) => {
-    console.log('Article clicked:', article.title);
-    // Implement navigation to article detail page
+    router.push(`/ensiklopedia/${article.slug}`);
   };
 
   const handlePageChange = (page: number) => {

--- a/src/components/ensiklopedia/index.ts
+++ b/src/components/ensiklopedia/index.ts
@@ -9,6 +9,7 @@ export { EncyclopediaViewToggle } from './encyclopedia-view-toggle';
 export { EncyclopediaFeaturedCard } from './encyclopedia-featured-card';
 export { EncyclopediaArticleCard } from './encyclopedia-article-card';
 export { EncyclopediaPagination } from './encyclopedia-pagination';
+export { EncyclopediaDetailMain } from './encyclopedia-detail-main';
 
 export type {
   Stat,

--- a/src/components/landing-page/encyclopedia-section.tsx
+++ b/src/components/landing-page/encyclopedia-section.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { ChevronRight, Search } from 'lucide-react';
+import Link from 'next/link';
 
 import { latestArticles, popularSearchTags } from './data';
 
@@ -40,7 +41,7 @@ export function EncyclopediaSection() {
                 asChild
                 className="inline-flex h-12 items-center bg-[#d5c8b3] px-6 text-sm font-bold text-[#2d5f48] transition hover:bg-[#e6dccc]"
               >
-                <a href="/ensiklopedia">Cari</a>
+                <Link href="/ensiklopedia">Cari</Link>
               </Button>
             </div>
 
@@ -96,10 +97,10 @@ export function EncyclopediaSection() {
               asChild
               className="mt-5 inline-flex items-center gap-1 text-sm font-semibold text-[#d4e1d2] transition hover:text-white"
             >
-              <a href="/ensiklopedia">
+              <Link href="/ensiklopedia">
                 Lihat semua artikel
                 <ChevronRight className="h-4 w-4" />
-              </a>
+              </Link>
             </Button>
           </aside>
         </div>

--- a/src/components/landing-page/hero-section.tsx
+++ b/src/components/landing-page/hero-section.tsx
@@ -3,6 +3,7 @@
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ChevronRight } from 'lucide-react';
+import Link from 'next/link';
 
 export function HeroSection() {
   return (
@@ -40,7 +41,7 @@ export function HeroSection() {
             asChild
             className="rounded-xl border border-[#c7b59b] bg-white/10 px-5 py-2.5 text-sm font-semibold text-[#f8f3e9] transition hover:bg-white/15"
           >
-            <a href="/ensiklopedia">Jelajahi Ensiklopedia</a>
+            <Link href="/ensiklopedia">Jelajahi Ensiklopedia</Link>
           </Button>
         </div>
       </div>

--- a/src/types/encyclopedia.ts
+++ b/src/types/encyclopedia.ts
@@ -14,6 +14,7 @@ export interface RegionFilter {
 }
 
 export interface EncyclopediaArticle {
+  slug: string;
   region: string;
   topic: string;
   motifLabel: string;
@@ -23,6 +24,41 @@ export interface EncyclopediaArticle {
   views: string;
   readMinutes?: number;
   featured?: boolean;
+}
+
+export interface EncyclopediaSection {
+  title: string;
+  content: string;
+  imageLabel?: string;
+  imageCaption?: string;
+}
+
+export interface EncyclopediaKeyFact {
+  label: string;
+  value: string;
+}
+
+export interface EncyclopediaRelatedProduct {
+  name: string;
+  location: string;
+  price: string;
+}
+
+export interface EncyclopediaArticleDetail extends EncyclopediaArticle {
+  author: string;
+  publishedAt: string;
+  tags: string[];
+  quote: string;
+  intro: string;
+  sections: EncyclopediaSection[];
+  keyFacts: EncyclopediaKeyFact[];
+  relatedProducts: EncyclopediaRelatedProduct[];
+  discussionCount: number;
+  nextArticle: {
+    slug: string;
+    title: string;
+  };
+  references: string[];
 }
 
 export type ViewMode = 'grid' | 'list';


### PR DESCRIPTION
## What kind of change does this PR introduce?
Feature (UI enhancement).

## What is the current behavior?
The encyclopedia page currently focuses on list view only.
Users can browse article cards, but there is no dedicated expanded article detail page with full structured content.
No related issue is linked yet (N/A).

## What is the new behavior?
This PR adds an expanded encyclopedia detail experience:
1. Users can open a dedicated detail page for each article using slug-based navigation.
2. Article cards now navigate to their respective detail pages.
3. Detail view includes richer content sections such as intro, key facts, references, related products, and next-article navigation.