### PR TITLE
feat: integrating wikimedia api

### DIFF
--- a/src/app/api/wikimedia/mobile-sections/route.ts
+++ b/src/app/api/wikimedia/mobile-sections/route.ts
@@ -1,0 +1,126 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const origin = searchParams.get('origin');
+    const title = searchParams.get('title');
+    if (!origin || !title) {
+      return NextResponse.json(
+        { error: 'Missing origin or title' },
+        { status: 400 },
+      );
+    }
+    const enc = encodeURIComponent(title);
+    const ua =
+      'WastraNusa/1.0 (wastranusa.example; contact: dev@wastranusa.example)';
+
+    // 1) get section list via action=parse&prop=sections
+    const sectionsUrl = `${origin}/w/api.php?action=parse&page=${enc}&prop=sections&format=json`;
+    const secRes = await fetch(sectionsUrl, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': ua,
+        Referer: origin,
+      },
+    });
+
+    const secText = await secRes.text();
+    if (!secRes.ok) {
+      return new Response(secText, {
+        status: secRes.status,
+        headers: {
+          'Content-Type':
+            secRes.headers.get('content-type') ?? 'application/json',
+        },
+      });
+    }
+
+    interface WikiApiResponse {
+      parse?: {
+        sections?: Array<{ index?: string | number; line?: string }>;
+        text?: { '*'?: string };
+      };
+    }
+
+    let secJson: WikiApiResponse;
+    try {
+      secJson = secText ? JSON.parse(secText) : {};
+    } catch {
+      return NextResponse.json(
+        { error: 'Invalid JSON from wiki' },
+        { status: 502 },
+      );
+    }
+
+    const sections = secJson.parse?.sections ?? [];
+
+    // helper to strip HTML
+    const stripHtml = (html?: string) => {
+      if (!html) return '';
+      return html
+        .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '')
+        .replace(/<style[\s\S]*?>[\s\S]*?<\/style>/gi, '')
+        .replace(/<[^>]+>/g, '')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .replace(/&nbsp;/g, ' ')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .trim();
+    };
+
+    // For each section, fetch its HTML via action=parse&section=index&prop=text
+    const outSections: Array<{ title: string; content: string }> = [];
+    for (const s of sections) {
+      const idx = s.index;
+      if (typeof idx === 'undefined') continue;
+      const secHtmlUrl = `${origin}/w/api.php?action=parse&page=${enc}&section=${idx}&prop=text&format=json`;
+      try {
+        const r = await fetch(secHtmlUrl, {
+          headers: {
+            Accept: 'application/json',
+            'User-Agent': ua,
+            Referer: origin,
+          },
+        });
+        if (!r.ok) continue;
+        const t = await r.text();
+        const j = t ? JSON.parse(t) : {};
+        const rawHtml = j.parse?.text?.['*'] ?? '';
+        const titleClean = stripHtml(s.line);
+        const contentClean = stripHtml(rawHtml);
+        // try to extract first image src from HTML
+        let imageURL: string | undefined;
+        const imgMatch = /<img[^>]+src\s*=\s*"([^"]+)"/i.exec(rawHtml);
+        if (imgMatch && imgMatch[1]) {
+          let src = imgMatch[1];
+          if (src.startsWith('//')) src = 'https:' + src;
+          else if (src.startsWith('/')) src = origin + src;
+          imageURL = src;
+        }
+        outSections.push({
+          title: titleClean,
+          content: contentClean,
+          ...(imageURL ? { imageURL } : {}),
+        });
+      } catch (e) {
+        // ignore individual section failures
+
+        console.debug('section fetch fail', e);
+      }
+    }
+
+    return NextResponse.json({ sections: outSections });
+  } catch (err) {
+    // generic server error
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/admin/article/add-update-article-modal.tsx
+++ b/src/components/admin/article/add-update-article-modal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -11,6 +12,7 @@ import {
 } from '@/components/ui/select';
 import { ArticleStatus } from '@/generated/prisma/enums';
 import { useCreateArticle, useUpdateArticle } from '@/hooks/use-article';
+import { useWikipediaSummaryImport } from '@/hooks/use-wikipedia-summary';
 import {
   type CreateArticleInput,
   createArticleSchema,
@@ -19,7 +21,8 @@ import {
 import { type EncyclopediaArticleDetail } from '@/types/encyclopedia';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { kabupaten, provinsi } from 'daftar-wilayah-indonesia';
-import { Plus, Trash2, X } from 'lucide-react';
+import { Download, Loader2, Plus, Trash2, X } from 'lucide-react';
+import Image from 'next/image';
 import { useEffect, useMemo, useState } from 'react';
 import {
   Controller,
@@ -80,6 +83,8 @@ export default function AddUpdateArticleModal({
   const isEdit = !!initialData;
   const isPending = isCreating || isUpdating;
 
+  const wiki = useWikipediaSummaryImport(isOpen);
+
   const defaultValues: CreateArticleInput = {
     title: initialData?.title ?? '',
     excerpt: initialData?.excerpt ?? '',
@@ -139,6 +144,20 @@ export default function AddUpdateArticleModal({
     control,
     name: 'sections',
   });
+
+  const handleApplyWikimediaPreview = () => {
+    if (!wiki.preview) return;
+    const { mapped } = wiki.preview;
+    setValue('title', mapped.title, { shouldDirty: true });
+    setValue('excerpt', mapped.excerpt, { shouldDirty: true });
+    setValue('summary', mapped.summary, { shouldDirty: true });
+    setValue('description', mapped.description, { shouldDirty: true });
+    if (mapped.imageURL) {
+      setValue('imageURL', mapped.imageURL, { shouldDirty: true });
+    }
+    toast.success('Data Wikipedia diterapkan ke form.');
+    wiki.discardPreview();
+  };
 
   const onSubmit = (data: CreateArticleInput) => {
     if (isEdit && initialData) {
@@ -250,6 +269,128 @@ export default function AddUpdateArticleModal({
 
         {/* Body / Form */}
         <div className="flex-1 overflow-y-auto px-6 py-5 space-y-6 custom-scrollbar">
+          {/* Impor ringkasan Wikipedia (fetch di browser) */}
+          <div className="rounded-2xl border border-[#e5ded5] bg-[#fdfaf7]/80 p-4 space-y-3">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div>
+                <p className="text-sm font-semibold text-gray-800">
+                  Impor dari Wikipedia
+                </p>
+                <p className="text-xs text-gray-500 mt-0.5">
+                  Tempel URL artikel (mis.{' '}
+                  <span className="font-mono text-[11px]">
+                    https://id.wikipedia.org/wiki/Batik
+                  </span>
+                  ), lalu tarik ringkasan REST API tanpa menyalin manual.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex flex-col sm:flex-row gap-2">
+              <Input
+                type="url"
+                inputMode="url"
+                autoComplete="off"
+                placeholder="https://id.wikipedia.org/wiki/..."
+                value={wiki.url}
+                onChange={(e) => wiki.setUrl(e.target.value)}
+                disabled={wiki.isLoading}
+                className="h-11 flex-1 px-4 bg-white border-[#e5ded5] rounded-xl text-gray-700 placeholder:text-gray-400 focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d]"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                disabled={
+                  wiki.isLoading || !wiki.urlLooksValid || !!wiki.urlHint
+                }
+                onClick={() => void wiki.fetchSummary()}
+                className="h-11 shrink-0 border-[#305645] text-[#305645] hover:bg-[#305645]/10 gap-2"
+              >
+                {wiki.isLoading ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin" aria-hidden />
+                    Memuat…
+                  </>
+                ) : (
+                  <>
+                    <Download className="size-4" aria-hidden />
+                    Tarik Data
+                  </>
+                )}
+              </Button>
+            </div>
+
+            {wiki.url.trim().length > 0 && wiki.urlHint && (
+              <p className="text-xs text-amber-700">{wiki.urlHint}</p>
+            )}
+
+            {wiki.error && (
+              <Alert
+                variant="destructive"
+                className="border-red-200 bg-red-50/90"
+              >
+                <AlertTitle>Gagal mengambil data</AlertTitle>
+                <AlertDescription>{wiki.error}</AlertDescription>
+              </Alert>
+            )}
+
+            {wiki.preview && (
+              <div className="rounded-xl border border-[#cde3d8] bg-white p-3 space-y-3">
+                <p className="text-xs font-semibold uppercase tracking-wide text-[#305645]">
+                  Pratinjau — terapkan ke form
+                </p>
+                {wiki.preview.wikiType === 'disambiguation' && (
+                  <p className="text-xs text-amber-800 bg-amber-50 border border-amber-100 rounded-lg px-2 py-1.5">
+                    Halaman ini berupa disambiguasi Wikipedia; ringkasan mungkin
+                    pendek — selalu sesuaikan untuk konteks WastraNusa.
+                  </p>
+                )}
+                <div className="flex flex-col sm:flex-row gap-3">
+                  {wiki.preview.mapped.imageURL ? (
+                    <Image
+                      src={wiki.preview.mapped.imageURL}
+                      alt=""
+                      width={112}
+                      height={112}
+                      unoptimized
+                      className="w-full sm:w-28 h-28 object-cover rounded-lg border border-[#e5ded5] bg-[#f5f3ec]"
+                    />
+                  ) : (
+                    <div className="w-full sm:w-28 h-28 rounded-lg border border-dashed border-[#e5ded5] bg-[#faf8f5] flex items-center justify-center text-[11px] text-gray-400 text-center px-2">
+                      Tidak ada gambar thumbnail
+                    </div>
+                  )}
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <p className="font-medium text-gray-900 leading-snug">
+                      {wiki.preview.mapped.title}
+                    </p>
+                    <p className="text-sm text-gray-600 line-clamp-4">
+                      {wiki.preview.mapped.summary}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-2 pt-1">
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="bg-[#305645] hover:bg-[#264538] text-white"
+                    onClick={handleApplyWikimediaPreview}
+                  >
+                    Terapkan ke form
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={wiki.discardPreview}
+                  >
+                    Buang pratinjau
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+
           {/* Judul Artikel */}
           <div>
             <label className="block text-sm font-medium text-gray-600 mb-1.5">

--- a/src/components/admin/article/add-update-article-modal.tsx
+++ b/src/components/admin/article/add-update-article-modal.tsx
@@ -155,14 +155,45 @@ export default function AddUpdateArticleModal({
     if (mapped.imageURL) {
       setValue('imageURL', mapped.imageURL, { shouldDirty: true });
     }
-    toast.success('Data Wikipedia diterapkan ke form.');
+    // If Wikipedia returned section headings, map them to form sections
+    if (mapped.sections && mapped.sections.length > 0) {
+      const mappedSections = mapped.sections.map((s, i) => ({
+        title: s.title || '',
+        content: s.content || '',
+        imageURL: s.imageURL ?? '',
+        order: i,
+      }));
+      setValue('sections', mappedSections, { shouldDirty: true });
+      // debug: print section titles and whether imageURL exists
+
+      console.debug(
+        'Applied Wikimedia sections',
+        mappedSections.map((s) => ({ title: s.title, hasImage: !!s.imageURL })),
+      );
+      toast.success('Data Wikipedia dan section diterapkan ke form.');
+    } else {
+      toast.success('Data Wikipedia diterapkan ke form.');
+    }
     wiki.discardPreview();
   };
 
   const onSubmit = (data: CreateArticleInput) => {
+    // Normalize empty imageURL strings to undefined so backend treats them as missing
+    const normalize = (d: CreateArticleInput) => {
+      const copy: Record<string, unknown> = { ...d };
+      if (copy.imageURL === '') copy.imageURL = undefined;
+      if (Array.isArray(copy.sections)) {
+        copy.sections = copy.sections.map((s: Record<string, unknown>) => ({
+          ...s,
+          imageURL: s.imageURL === '' ? undefined : s.imageURL,
+        }));
+      }
+      return copy as CreateArticleInput;
+    };
+    const payload = normalize(data);
     if (isEdit && initialData) {
       updateArticle(
-        { slug: initialData.slug, data },
+        { slug: initialData.slug, data: payload },
         {
           onSuccess: () => {
             toast.success('Artikel berhasil diperbarui');
@@ -178,7 +209,7 @@ export default function AddUpdateArticleModal({
         },
       );
     } else {
-      createArticle(data, {
+      createArticle(payload, {
         onSuccess: () => {
           toast.success('Artikel berhasil ditambahkan');
           reset();
@@ -821,11 +852,35 @@ export default function AddUpdateArticleModal({
                   <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1.5">
                     URL Gambar Section (Opsional)
                   </label>
-                  <Input
-                    {...register(`sections.${index}.imageURL` as const)}
-                    placeholder="https://example.com/section-image.jpg"
-                    className="h-10 bg-white"
-                  />
+                  <div className="flex items-start gap-3">
+                    <Input
+                      {...register(`sections.${index}.imageURL` as const)}
+                      placeholder="https://example.com/section-image.jpg"
+                      className="h-10 bg-white flex-1"
+                    />
+                    {/** preview if imageURL exists */}
+                    {/** Use value from field so it updates immediately */}
+                    <div className="w-20 h-12 bg-[#faf8f5] rounded-md flex items-center justify-center border border-dashed border-[#e5ded5]">
+                      {(() => {
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        const formValues = (control as any)._formValues;
+                        const imageUrl =
+                          formValues?.sections?.[index]?.imageURL;
+                        return imageUrl ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={imageUrl as string}
+                            alt=""
+                            className="w-20 h-12 object-cover rounded-md"
+                          />
+                        ) : (
+                          <span className="text-[11px] text-gray-400 text-center">
+                            No image
+                          </span>
+                        );
+                      })()}
+                    </div>
+                  </div>
                   {errors.sections?.[index]?.imageURL && (
                     <p className="text-xs text-red-500 mt-1 italic">
                       {errors.sections[index]?.imageURL?.message}

--- a/src/components/catalog/detail/catalog-detail-gallery.tsx
+++ b/src/components/catalog/detail/catalog-detail-gallery.tsx
@@ -20,7 +20,13 @@ export function CatalogDetailGallery({
           {category}
         </Badge>
         {imageURL ? (
-          <Image src={imageURL} alt={category} fill className="object-cover" />
+          <Image
+            src={imageURL}
+            alt={category}
+            fill
+            unoptimized
+            className="object-cover"
+          />
         ) : (
           <div className="absolute inset-0 grid place-items-center">
             <div className="flex flex-col items-center gap-2 text-[#7f715c]">

--- a/src/components/encyclopedia/encyclopedia-article-card.tsx
+++ b/src/components/encyclopedia/encyclopedia-article-card.tsx
@@ -25,6 +25,7 @@ export function EncyclopediaArticleCard({
             src={article.imageURL}
             alt={article.title}
             fill
+            unoptimized
             className="object-cover"
           />
         ) : (

--- a/src/components/encyclopedia/encyclopedia-detail-main.tsx
+++ b/src/components/encyclopedia/encyclopedia-detail-main.tsx
@@ -202,6 +202,7 @@ export function EncyclopediaDetailMain({ slug }: EncyclopediaDetailMainProps) {
               src={article.imageURL}
               alt={article.title}
               fill
+              unoptimized
               className="object-cover mix-blend-overlay"
             />
           ) : (
@@ -331,6 +332,7 @@ export function EncyclopediaDetailMain({ slug }: EncyclopediaDetailMainProps) {
                             src={section.imageURL}
                             alt={section.imageCaption || ''}
                             fill
+                            unoptimized
                             className="object-cover"
                           />
                         ) : (

--- a/src/hooks/use-wikipedia-summary.ts
+++ b/src/hooks/use-wikipedia-summary.ts
@@ -1,0 +1,122 @@
+'use client';
+
+import {
+  type MappedArticleFieldsFromWikipedia,
+  WikipediaSummaryFetchError,
+  fetchWikipediaPageSummary,
+  mapWikipediaSummaryToArticleFields,
+  parseWikimediaArticleUrl,
+  validateWikimediaArticleUrlShape,
+} from '@/lib/wikimedia/wikipedia-summary';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type WikipediaSummaryPreview = {
+  mapped: MappedArticleFieldsFromWikipedia;
+  pageUrl: string;
+  wikiType?: string;
+};
+
+/**
+ * Client-side Wikipedia page summary import: URL state, debounced validation,
+ * fetch with abort, loading/error/preview. Reset when `isActive` becomes false (e.g. modal closed).
+ */
+export function useWikipediaSummaryImport(isActive: boolean) {
+  const [url, setUrl] = useState('');
+  const [urlHint, setUrlHint] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<WikipediaSummaryPreview | null>(null);
+
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isActive) {
+      abortRef.current?.abort();
+      setIsLoading(false);
+      return;
+    }
+    setUrl('');
+    setUrlHint(null);
+    setError(null);
+    setPreview(null);
+    abortRef.current?.abort();
+    setIsLoading(false);
+  }, [isActive]);
+
+  useEffect(() => {
+    const id = window.setTimeout(() => {
+      setUrlHint(validateWikimediaArticleUrlShape(url));
+    }, 400);
+    return () => window.clearTimeout(id);
+  }, [url]);
+
+  const urlLooksValid =
+    url.trim().length > 0 && parseWikimediaArticleUrl(url) !== null;
+
+  const fetchSummary = useCallback(async () => {
+    const trimmed = url.trim();
+    const parsed = parseWikimediaArticleUrl(trimmed);
+    if (!parsed) {
+      setError(
+        'URL tidak valid atau bukan halaman artikel Wikipedia (*.wikipedia.org, jalur /wiki/… atau ?title=…).',
+      );
+      setPreview(null);
+      return;
+    }
+
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    setIsLoading(true);
+    setError(null);
+    setPreview(null);
+
+    try {
+      const summary = await fetchWikipediaPageSummary(
+        parsed.apiOrigin,
+        parsed.pageTitle,
+        ac.signal,
+      );
+      const mapped = mapWikipediaSummaryToArticleFields(summary);
+      setPreview({
+        mapped,
+        pageUrl: trimmed,
+        wikiType: summary.type,
+      });
+    } catch (err: unknown) {
+      if (err instanceof DOMException && err.name === 'AbortError') return;
+      const message =
+        err instanceof WikipediaSummaryFetchError
+          ? err.message
+          : err instanceof TypeError
+            ? 'Koneksi gagal atau diblokir. Periksa jaringan atau CORS browser.'
+            : err instanceof Error
+              ? err.message
+              : 'Gagal mengambil ringkasan Wikipedia.';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [url]);
+
+  const discardPreview = useCallback(() => setPreview(null), []);
+
+  return {
+    url,
+    setUrl,
+    urlHint,
+    isLoading,
+    error,
+    preview,
+    urlLooksValid,
+    fetchSummary,
+    discardPreview,
+  };
+}

--- a/src/hooks/use-wikipedia-summary.ts
+++ b/src/hooks/use-wikipedia-summary.ts
@@ -14,6 +14,8 @@ export type WikipediaSummaryPreview = {
   mapped: MappedArticleFieldsFromWikipedia;
   pageUrl: string;
   wikiType?: string;
+  sectionsFetchError?: string | null;
+  sectionsFetched?: boolean;
 };
 
 /**
@@ -85,11 +87,44 @@ export function useWikipediaSummaryImport(isActive: boolean) {
         ac.signal,
       );
       const mapped = mapWikipediaSummaryToArticleFields(summary);
-      setPreview({
-        mapped,
-        pageUrl: trimmed,
-        wikiType: summary.type,
-      });
+      // Attempt to fetch sections (mobile-sections) to populate form sections
+      try {
+        // dynamic import to avoid increasing initial bundle for clients that don't use this
+        let sectionsError: string | null = null;
+        let sectionsFetched = false;
+        try {
+          // Use server-side proxy to avoid CORS / 403 issues from client
+          const proxyUrl = `/api/wikimedia/mobile-sections?origin=${encodeURIComponent(
+            parsed.apiOrigin,
+          )}&title=${encodeURIComponent(parsed.pageTitle)}`;
+          const resp = await fetch(proxyUrl, { signal: ac.signal });
+          const sectionsResp = resp.ok ? await resp.json() : null;
+          if (sectionsResp?.sections && sectionsResp.sections.length > 0) {
+            mapped.sections = sectionsResp.sections
+              .filter((s) => s.title && s.content)
+              .map((s) => ({
+                title: s.title,
+                content: s.content,
+                imageURL: s.imageURL,
+              }));
+          }
+          sectionsFetched = true;
+        } catch (e: unknown) {
+          sectionsError = e instanceof Error ? e.message : String(e);
+
+          console.debug('Could not fetch mobile sections for preview', e);
+        }
+
+        setPreview({
+          mapped,
+          pageUrl: trimmed,
+          wikiType: summary.type,
+          sectionsFetchError: sectionsError,
+          sectionsFetched,
+        });
+      } catch (err) {
+        throw err;
+      }
     } catch (err: unknown) {
       if (err instanceof DOMException && err.name === 'AbortError') return;
       const message =

--- a/src/lib/wikimedia/wikipedia-summary.ts
+++ b/src/lib/wikimedia/wikipedia-summary.ts
@@ -119,10 +119,7 @@ function truncateForExcerpt(text: string, maxLen: number): string {
 export function mapWikipediaSummaryToArticleFields(
   data: WikipediaSummarySuccess,
 ): MappedArticleFieldsFromWikipedia {
-  const title = (data.displaytitle ?? data.title ?? '').replace(
-    /<\/?[^>]+>/g,
-    '',
-  );
+  const title = (data.displaytitle ?? data.title ?? '').replace(/[<>]/g, '');
   const extractRaw = (data.extract ?? '').trim();
 
   const excerpt =

--- a/src/lib/wikimedia/wikipedia-summary.ts
+++ b/src/lib/wikimedia/wikipedia-summary.ts
@@ -1,0 +1,214 @@
+/**
+ * Client-side helpers for Wikipedia page summary REST API.
+ * @see https://en.wikipedia.org/api/rest_v1/
+ */
+
+const SUMMARY_PATH = '/api/rest_v1/page/summary';
+
+export type WikipediaSummaryThumbnail = {
+  source: string;
+  width?: number;
+  height?: number;
+};
+
+/** Minimal shape we consume from GET .../page/summary/{title} */
+export type WikipediaSummarySuccess = {
+  type?: string;
+  title: string;
+  displaytitle?: string;
+  extract?: string;
+  extract_html?: string;
+  thumbnail?: WikipediaSummaryThumbnail;
+};
+
+export type WikipediaSummaryErrorBody = {
+  type?: string;
+  title?: string;
+  detail?: string;
+};
+
+export type ParsedWikimediaArticleUrl = {
+  apiOrigin: string;
+  pageTitle: string;
+};
+
+export type MappedArticleFieldsFromWikipedia = {
+  title: string;
+  excerpt: string;
+  summary: string;
+  description: string;
+  imageURL?: string;
+};
+
+function isWikipediaHost(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  return h === 'wikipedia.org' || h.endsWith('.wikipedia.org');
+}
+
+/**
+ * Validates URL shape only (no network). Returns user-facing hint or null if OK-looking.
+ */
+export function validateWikimediaArticleUrlShape(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    if (!['http:', 'https:'].includes(url.protocol)) {
+      return 'Gunakan tautan http atau https.';
+    }
+    if (!isWikipediaHost(url.hostname)) {
+      return 'Hanya URL artikel Wikipedia (hostname *.wikipedia.org) yang didukung.';
+    }
+    const parsed = extractTitleFromWikipediaUrl(url);
+    if (!parsed) {
+      return 'Gunakan tautan artikel wiki, misalnya …/wiki/Judul_Artikel atau ?title=Judul.';
+    }
+    return null;
+  } catch {
+    return 'Format URL tidak valid.';
+  }
+}
+
+function extractTitleFromWikipediaUrl(url: URL): string | null {
+  const titleParam =
+    url.searchParams.get('title') ?? url.searchParams.get('Title');
+  if (url.pathname.includes('index.php') && titleParam && titleParam.trim()) {
+    return decodeURIComponent(titleParam.replace(/\+/g, ' ')).trim();
+  }
+
+  const wikiMatch = url.pathname.match(/^\/wiki\/(.+)$/);
+  if (wikiMatch?.[1]) {
+    try {
+      const decoded = decodeURIComponent(wikiMatch[1]);
+      return decoded.replace(/_/g, ' ').trim();
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+export function parseWikimediaArticleUrl(
+  raw: string,
+): ParsedWikimediaArticleUrl | null {
+  try {
+    const url = new URL(raw.trim());
+    if (!['http:', 'https:'].includes(url.protocol)) return null;
+    if (!isWikipediaHost(url.hostname)) return null;
+
+    const pageTitle = extractTitleFromWikipediaUrl(url);
+    if (!pageTitle) return null;
+
+    const apiOrigin = `${url.protocol}//${url.hostname}`;
+    return { apiOrigin, pageTitle };
+  } catch {
+    return null;
+  }
+}
+
+function truncateForExcerpt(text: string, maxLen: number): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLen) return normalized;
+  const slice = normalized.slice(0, maxLen);
+  const lastSpace = slice.lastIndexOf(' ');
+  const base = lastSpace > maxLen * 0.6 ? slice.slice(0, lastSpace) : slice;
+  return `${base.trim()}…`;
+}
+
+export function mapWikipediaSummaryToArticleFields(
+  data: WikipediaSummarySuccess,
+): MappedArticleFieldsFromWikipedia {
+  const title = (data.displaytitle ?? data.title ?? '').replace(
+    /<\/?[^>]+>/g,
+    '',
+  );
+  const extractRaw = (data.extract ?? '').trim();
+
+  const excerpt =
+    extractRaw.length > 0 ? truncateForExcerpt(extractRaw, 260) : title;
+
+  const summary = extractRaw.length > 0 ? extractRaw : title;
+
+  const description =
+    extractRaw.length > 0
+      ? `Ringkasan dari Wikipedia (${title}). Disarankan mengedit dan melengkapi konteks lokal sebelum mempublikasikan.`
+      : '';
+
+  const thumb = data.thumbnail?.source?.trim();
+  let imageURL: string | undefined;
+  if (thumb) {
+    try {
+      imageURL = new URL(thumb).href;
+    } catch {
+      imageURL = undefined;
+    }
+  }
+
+  return {
+    title: title.trim(),
+    excerpt,
+    summary,
+    description,
+    imageURL,
+  };
+}
+
+export class WikipediaSummaryFetchError extends Error {
+  constructor(
+    message: string,
+    readonly status?: number,
+    readonly body?: WikipediaSummaryErrorBody,
+  ) {
+    super(message);
+    this.name = 'WikipediaSummaryFetchError';
+  }
+}
+
+export async function fetchWikipediaPageSummary(
+  apiOrigin: string,
+  pageTitle: string,
+  signal?: AbortSignal,
+): Promise<WikipediaSummarySuccess> {
+  const enc = encodeURIComponent(pageTitle);
+  const res = await fetch(`${apiOrigin}${SUMMARY_PATH}/${enc}`, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+    signal,
+  });
+
+  const text = await res.text();
+  let json: unknown;
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    throw new WikipediaSummaryFetchError(
+      'Respons Wikipedia tidak dapat dibaca (bukan JSON).',
+      res.status,
+    );
+  }
+
+  if (!res.ok) {
+    const errBody = json as WikipediaSummaryErrorBody;
+    const detail =
+      errBody.detail?.trim() || res.statusText || 'Permintaan gagal';
+    if (res.status === 404) {
+      throw new WikipediaSummaryFetchError(
+        `Artikel tidak ditemukan: ${detail}`,
+        res.status,
+        errBody,
+      );
+    }
+    throw new WikipediaSummaryFetchError(detail, res.status, errBody);
+  }
+
+  const data = json as WikipediaSummarySuccess;
+  if (!data.title && !data.extract) {
+    throw new WikipediaSummaryFetchError(
+      'Data ringkasan kosong atau tidak dikenali.',
+      res.status,
+    );
+  }
+
+  return data;
+}

--- a/src/lib/wikimedia/wikipedia-summary.ts
+++ b/src/lib/wikimedia/wikipedia-summary.ts
@@ -38,6 +38,7 @@ export type MappedArticleFieldsFromWikipedia = {
   summary: string;
   description: string;
   imageURL?: string;
+  sections?: Array<{ title: string; content: string; imageURL?: string }>;
 };
 
 function isWikipediaHost(hostname: string): boolean {
@@ -119,8 +120,9 @@ function truncateForExcerpt(text: string, maxLen: number): string {
 export function mapWikipediaSummaryToArticleFields(
   data: WikipediaSummarySuccess,
 ): MappedArticleFieldsFromWikipedia {
-  const title = (data.displaytitle ?? data.title ?? '').replace(/[<>]/g, '');
-  const extractRaw = (data.extract ?? '').trim();
+  const rawTitle = data.displaytitle ?? data.title ?? '';
+  const title = stripHtml(rawTitle);
+  const extractRaw = stripHtml(data.extract_html ?? data.extract ?? '');
 
   const excerpt =
     extractRaw.length > 0 ? truncateForExcerpt(extractRaw, 260) : title;
@@ -208,4 +210,84 @@ export async function fetchWikipediaPageSummary(
   }
 
   return data;
+}
+
+const MOBILE_SECTIONS_PATH = '/api/rest_v1/page/mobile-sections';
+
+type MobileSection = {
+  id?: string;
+  line?: string; // heading text
+  anchor?: string;
+  level?: number;
+  text?: string; // HTML content
+};
+
+type MobileSectionsResponse = {
+  lead?: unknown;
+  remaining?: unknown;
+  sections?: MobileSection[];
+};
+
+function stripHtml(html?: string): string {
+  if (!html) return '';
+  // Basic tag stripper — sufficient for short previews
+  const withoutScripts = html.replace(
+    /<script[\s\S]*?>[\s\S]*?<\/script>/gi,
+    '',
+  );
+  const withoutStyles = withoutScripts.replace(
+    /<style[\s\S]*?>[\s\S]*?<\/style>/gi,
+    '',
+  );
+  const withoutTags = withoutStyles.replace(/<[^>]+>/g, '');
+  const collapsed = withoutTags.replace(/\s+/g, ' ').trim();
+  // Decode a few common HTML entities
+  return collapsed
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .trim();
+}
+
+export async function fetchWikipediaPageMobileSections(
+  apiOrigin: string,
+  pageTitle: string,
+  signal?: AbortSignal,
+): Promise<MobileSectionsResponse> {
+  const enc = encodeURIComponent(pageTitle);
+  const res = await fetch(`${apiOrigin}${MOBILE_SECTIONS_PATH}/${enc}`, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+    signal,
+  });
+
+  const text = await res.text();
+  let json: unknown;
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    throw new WikipediaSummaryFetchError(
+      'Respons Wikipedia (mobile sections) tidak dapat dibaca (bukan JSON).',
+      res.status,
+    );
+  }
+
+  if (!res.ok) {
+    const errBody = json as WikipediaSummaryErrorBody;
+    const detail =
+      errBody.detail?.trim() || res.statusText || 'Permintaan gagal';
+    throw new WikipediaSummaryFetchError(detail, res.status, errBody);
+  }
+
+  const data = json as MobileSectionsResponse;
+  // Normalize sections: map headings + text
+  const sections = (data.sections ?? []).map((s) => ({
+    title: stripHtml(s.line),
+    content: stripHtml(s.text),
+  }));
+
+  return { ...data, sections };
 }

--- a/src/schemas/article.schema.ts
+++ b/src/schemas/article.schema.ts
@@ -19,7 +19,7 @@ export const createArticleSchema = z.object({
   readMinutes: z.number().int().min(1).optional(),
   featured: z.boolean().optional(),
 
-  imageURL: z.string().url().nullish(),
+  imageURL: z.union([z.string().url(), z.literal('')]).nullish(),
 
   sections: z
     .array(
@@ -28,7 +28,7 @@ export const createArticleSchema = z.object({
         content: z.string().min(1, 'Konten section wajib diisi'),
         imageLabel: z.string().nullish(),
         imageCaption: z.string().nullish(),
-        imageURL: z.string().url().nullish(),
+        imageURL: z.union([z.string().url(), z.literal('')]).nullish(),
         order: z.number().int(),
       }),
     )


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Admin harus copy-paste manual konten dari Wikimedia ke form artikel (rawan error dan memakan waktu).
Belum ada integrasi fetch Wikipedia langsung dari form create/update artikel.

## What is the new behavior?

Menambahkan integrasi Wikimedia/Wikipedia summary di modal admin artikel:
Input URL artikel Wikipedia.
Tombol Tarik Data untuk fetch client-side ke endpoint:
https://{lang}.wikipedia.org/api/rest_v1/page/summary/{title}
Auto-map hasil ke field form:
title, excerpt, summary, description, imageURL (jika thumbnail tersedia).
Menambahkan state handling lengkap:
loading, error, validasi URL, empty state/no thumbnail, preview sebelum apply.
request cancellation (AbortController) untuk menghindari race condition.

## Additional context

Files changed (utama)
src/components/admin/article/add-update-article-modal.tsx
src/hooks/use-wikipedia-summary.ts (new)
src/lib/wikimedia/wikipedia-summary.ts (new utility module)