### PR TITLE
feat(ui): polish UI consistency, interactivity, and fix buy-now image

### DIFF
--- a/src/components/admin/article/add-update-article-modal.tsx
+++ b/src/components/admin/article/add-update-article-modal.tsx
@@ -265,7 +265,7 @@ export default function AddUpdateArticleModal({
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-[#ebdxc2]">
-          <div className="flex items-center gap-3 text-gray-800">
+          <div className="flex items-center gap-3 text-foreground">
             <svg
               className="w-5 h-5 text-[#8c6b5d]"
               fill="none"
@@ -288,7 +288,7 @@ export default function AddUpdateArticleModal({
             variant="ghost"
             size="icon-sm"
             onClick={onClose}
-            className="bg-[#f3ede8] hover:bg-[#e6dcd5] rounded-full text-gray-500 transition-colors"
+            className="bg-[#f3ede8] hover:bg-[#e6dcd5] rounded-full text-muted-foreground transition-colors"
           >
             <X className="w-4 h-4" />
           </Button>
@@ -300,10 +300,10 @@ export default function AddUpdateArticleModal({
           <div className="rounded-2xl border border-[#e5ded5] bg-[#fdfaf7]/80 p-4 space-y-3">
             <div className="flex flex-wrap items-start justify-between gap-2">
               <div>
-                <p className="text-sm font-semibold text-gray-800">
+                <p className="text-sm font-semibold text-foreground">
                   Impor dari Wikipedia
                 </p>
-                <p className="text-xs text-gray-500 mt-0.5">
+                <p className="text-xs text-muted-foreground mt-0.5">
                   Tempel URL artikel (mis.{' '}
                   <span className="font-mono text-[11px]">
                     https://id.wikipedia.org/wiki/Batik
@@ -322,7 +322,7 @@ export default function AddUpdateArticleModal({
                 value={wiki.url}
                 onChange={(e) => wiki.setUrl(e.target.value)}
                 disabled={wiki.isLoading}
-                className="h-11 flex-1 px-4 bg-white border-[#e5ded5] rounded-xl text-gray-700 placeholder:text-gray-400 focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d]"
+                className="h-11 flex-1 px-4 bg-white border-[#e5ded5] rounded-xl text-foreground placeholder:text-muted-foreground focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d]"
               />
               <Button
                 type="button"
@@ -383,15 +383,15 @@ export default function AddUpdateArticleModal({
                       className="w-full sm:w-28 h-28 object-cover rounded-lg border border-[#e5ded5] bg-[#f5f3ec]"
                     />
                   ) : (
-                    <div className="w-full sm:w-28 h-28 rounded-lg border border-dashed border-[#e5ded5] bg-[#faf8f5] flex items-center justify-center text-[11px] text-gray-400 text-center px-2">
+                    <div className="w-full sm:w-28 h-28 rounded-lg border border-dashed border-[#e5ded5] bg-[#faf8f5] flex items-center justify-center text-[11px] text-muted-foreground text-center px-2">
                       Tidak ada gambar thumbnail
                     </div>
                   )}
                   <div className="min-w-0 flex-1 space-y-1">
-                    <p className="font-medium text-gray-900 leading-snug">
+                    <p className="font-medium text-foreground leading-snug">
                       {wiki.preview.mapped.title}
                     </p>
-                    <p className="text-sm text-gray-600 line-clamp-4">
+                    <p className="text-sm text-muted-foreground line-clamp-4">
                       {wiki.preview.mapped.summary}
                     </p>
                   </div>
@@ -459,14 +459,14 @@ export default function AddUpdateArticleModal({
 
           {/* Judul Artikel */}
           <div>
-            <label className="block text-sm font-medium text-gray-600 mb-1.5">
+            <label className="block text-sm font-medium text-muted-foreground mb-1.5">
               Judul Artikel *
             </label>
             <Input
               {...register('title')}
               type="text"
               placeholder="Contoh: Sejarah Batik Jawa: Warisan Dunia UNESCO"
-              className="h-11 px-4 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-gray-700 placeholder:text-gray-400 focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d]"
+              className="h-11 px-4 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-foreground placeholder:text-muted-foreground focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d]"
             />
             {errors.title && (
               <p className="text-xs text-red-500 mt-1">
@@ -478,14 +478,14 @@ export default function AddUpdateArticleModal({
           <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
             {/* Motif Label */}
             <div>
-              <label className="block text-sm font-medium text-gray-600 mb-1.5">
+              <label className="block text-sm font-medium text-muted-foreground mb-1.5">
                 Label Motif *
               </label>
               <Input
                 {...register('motifLabel')}
                 type="text"
                 placeholder="Batik Parang / Songket Palembang"
-                className="h-11 px-4 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-gray-700 focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d]"
+                className="h-11 px-4 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-foreground focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d]"
               />
               {errors.motifLabel && (
                 <p className="text-xs text-red-500 mt-1 font-medium">
@@ -496,14 +496,14 @@ export default function AddUpdateArticleModal({
 
             {/* Topik */}
             <div>
-              <label className="block text-sm font-medium text-gray-600 mb-1.5">
+              <label className="block text-sm font-medium text-muted-foreground mb-1.5">
                 Topik *
               </label>
               <Input
                 {...register('topic')}
                 type="text"
                 placeholder="Pakaian Adat / Tekstil"
-                className="h-11 px-4 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-gray-700 focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d]"
+                className="h-11 px-4 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-foreground focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d]"
               />
               {errors.topic && (
                 <p className="text-xs text-red-500 mt-1">
@@ -514,7 +514,7 @@ export default function AddUpdateArticleModal({
 
             {/* Pulau */}
             <div>
-              <label className="block text-sm font-medium text-gray-600 mb-1.5">
+              <label className="block text-sm font-medium text-muted-foreground mb-1.5">
                 Pulau *
               </label>
               <Controller
@@ -529,7 +529,7 @@ export default function AddUpdateArticleModal({
                     }}
                     value={field.value || undefined}
                   >
-                    <SelectTrigger className="h-11 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-gray-700">
+                    <SelectTrigger className="h-11 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-foreground">
                       <SelectValue placeholder="Pilih Pulau" />
                     </SelectTrigger>
                     <SelectContent>
@@ -551,7 +551,7 @@ export default function AddUpdateArticleModal({
 
             {/* Provinsi */}
             <div>
-              <label className="block text-sm font-medium text-gray-600 mb-1.5">
+              <label className="block text-sm font-medium text-muted-foreground mb-1.5">
                 Provinsi *
               </label>
               <Controller
@@ -566,7 +566,7 @@ export default function AddUpdateArticleModal({
                     value={field.value || undefined}
                     disabled={!watchedIsland}
                   >
-                    <SelectTrigger className="h-11 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-gray-700">
+                    <SelectTrigger className="h-11 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-foreground">
                       <SelectValue
                         placeholder={
                           watchedIsland
@@ -594,7 +594,7 @@ export default function AddUpdateArticleModal({
 
             {/* Daerah */}
             <div>
-              <label className="block text-sm font-medium text-gray-600 mb-1.5">
+              <label className="block text-sm font-medium text-muted-foreground mb-1.5">
                 Daerah *
               </label>
               <Controller
@@ -606,7 +606,7 @@ export default function AddUpdateArticleModal({
                     value={field.value || undefined}
                     disabled={!watchedProvince}
                   >
-                    <SelectTrigger className="h-11 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-gray-700">
+                    <SelectTrigger className="h-11 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-foreground">
                       <SelectValue
                         placeholder={
                           watchedProvince
@@ -633,17 +633,17 @@ export default function AddUpdateArticleModal({
             </div>
 
             {/* Read Minutes, Gender, Featured, Status */}
-            <div className="block text-sm font-medium text-gray-600 mb-1.5">
+            <div className="block text-sm font-medium text-muted-foreground mb-1.5">
               {/* Estimasi Waktu Baca */}
               <div>
-                <label className="block text-sm font-medium text-gray-600 mb-1.5">
+                <label className="block text-sm font-medium text-muted-foreground mb-1.5">
                   Estimasi Waktu Baca (menit) *
                 </label>
                 <Input
                   {...register('readMinutes', { valueAsNumber: true })}
                   type="number"
                   placeholder="6"
-                  className="h-11 px-4 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-gray-700"
+                  className="h-11 px-4 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-foreground"
                 />
                 {errors.readMinutes && (
                   <p className="text-xs text-red-500 mt-1">
@@ -655,7 +655,7 @@ export default function AddUpdateArticleModal({
             <div className="grid grid-cols-2 gap-5">
               {/* Gender */}
               <div>
-                <label className="block text-sm font-medium text-gray-600 mb-1.5">
+                <label className="block text-sm font-medium text-muted-foreground mb-1.5">
                   Gender (Opsional)
                 </label>
                 <Controller
@@ -666,7 +666,7 @@ export default function AddUpdateArticleModal({
                       onValueChange={field.onChange}
                       value={field.value ?? undefined}
                     >
-                      <SelectTrigger className="h-11 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-gray-700">
+                      <SelectTrigger className="h-11 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-foreground">
                         <SelectValue placeholder="Pilih Gender" />
                       </SelectTrigger>
                       <SelectContent>
@@ -694,9 +694,9 @@ export default function AddUpdateArticleModal({
                       type="checkbox"
                       className="sr-only peer"
                     />
-                    <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-[#c26a3d]/20 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#c26a3d]"></div>
+                    <div className="w-11 h-6 bg-muted peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-[#c26a3d]/20 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-border after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#c26a3d]"></div>
                   </div>
-                  <span className="text-sm font-medium text-gray-600 group-hover:text-gray-800 transition-colors">
+                  <span className="text-sm font-medium text-muted-foreground group-hover:text-foreground transition-colors">
                     Tampilkan di Featured
                   </span>
                 </label>
@@ -707,14 +707,14 @@ export default function AddUpdateArticleModal({
           <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
             {/* Ethnic Group */}
             <div>
-              <label className="block text-sm font-medium text-gray-600 mb-1.5">
+              <label className="block text-sm font-medium text-muted-foreground mb-1.5">
                 Suku / Kelompok Etnis (Opsional)
               </label>
               <Input
                 {...register('ethnicGroup')}
                 type="text"
                 placeholder="Contoh: Jawa / Dayak"
-                className="h-11 px-4 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-gray-700"
+                className="h-11 px-4 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-foreground"
               />
               {errors.ethnicGroup && (
                 <p className="text-xs text-red-500 mt-1">
@@ -725,14 +725,14 @@ export default function AddUpdateArticleModal({
 
             {/* Clothing Type */}
             <div>
-              <label className="block text-sm font-medium text-gray-600 mb-1.5">
+              <label className="block text-sm font-medium text-muted-foreground mb-1.5">
                 Jenis Pakaian (Opsional)
               </label>
               <Input
                 {...register('clothingType')}
                 type="text"
                 placeholder="Contoh: Kebaya / Batik"
-                className="h-11 px-4 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-gray-700"
+                className="h-11 px-4 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-foreground"
               />
               {errors.clothingType && (
                 <p className="text-xs text-red-500 mt-1">
@@ -745,14 +745,14 @@ export default function AddUpdateArticleModal({
           {/* Excerpt, Summary, Description */}
           <div className="space-y-5">
             <div>
-              <label className="block text-sm font-medium text-gray-600 mb-1.5">
+              <label className="block text-sm font-medium text-muted-foreground mb-1.5">
                 Excerpt (Ringkasan Pendek) *
               </label>
               <textarea
                 {...register('excerpt')}
                 rows={2}
                 placeholder="Teaser singkat yang muncul di kartu artikel..."
-                className="w-full px-4 py-3 bg-[#fdfaf7] border border-[#e5ded5] rounded-xl text-gray-700 placeholder:text-gray-400 focus:outline-none focus-visible:ring-3 focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d] transition-all resize-none"
+                className="w-full px-4 py-3 bg-[#fdfaf7] border border-[#e5ded5] rounded-xl text-foreground placeholder:text-muted-foreground focus:outline-none focus-visible:ring-3 focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d] transition-all resize-none"
               />
               {errors.excerpt && (
                 <p className="text-xs text-red-500 mt-1">
@@ -762,14 +762,14 @@ export default function AddUpdateArticleModal({
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-600 mb-1.5">
+              <label className="block text-sm font-medium text-muted-foreground mb-1.5">
                 Ringkasan (Summary) (Opsional)
               </label>
               <textarea
                 {...register('summary')}
                 rows={3}
                 placeholder="Ringkasan lengkap tentang isi artikel..."
-                className="w-full px-4 py-3 bg-[#fdfaf7] border border-[#e5ded5] rounded-xl text-gray-700 placeholder:text-gray-400 focus:outline-none focus-visible:ring-3 focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d] transition-all resize-none"
+                className="w-full px-4 py-3 bg-[#fdfaf7] border border-[#e5ded5] rounded-xl text-foreground placeholder:text-muted-foreground focus:outline-none focus-visible:ring-3 focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d] transition-all resize-none"
               />
               {errors.summary && (
                 <p className="text-xs text-red-500 mt-1">
@@ -779,14 +779,14 @@ export default function AddUpdateArticleModal({
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-600 mb-1.5">
+              <label className="block text-sm font-medium text-muted-foreground mb-1.5">
                 Deskripsi Tambahan (Opsional)
               </label>
               <textarea
                 {...register('description')}
                 rows={3}
                 placeholder="Detail informasi tambahan lainnya..."
-                className="w-full px-4 py-3 bg-[#fdfaf7] border border-[#e5ded5] rounded-xl text-gray-700 placeholder:text-gray-400 focus:outline-none focus-visible:ring-3 focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d] transition-all resize-none"
+                className="w-full px-4 py-3 bg-[#fdfaf7] border border-[#e5ded5] rounded-xl text-foreground placeholder:text-muted-foreground focus:outline-none focus-visible:ring-3 focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d] transition-all resize-none"
               />
               {errors.description && (
                 <p className="text-xs text-red-500 mt-1">
@@ -796,14 +796,14 @@ export default function AddUpdateArticleModal({
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-600 mb-1.5">
+              <label className="block text-sm font-medium text-muted-foreground mb-1.5">
                 URL Gambar Utama (Opsional)
               </label>
               <Input
                 {...register('imageURL')}
                 type="text"
                 placeholder="https://example.com/image.jpg"
-                className="h-11 px-4 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-gray-700 placeholder:text-gray-400 focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d]"
+                className="h-11 px-4 bg-[#fdfaf7] border-[#e5ded5] rounded-xl text-foreground placeholder:text-muted-foreground focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d]"
               />
               {errors.imageURL && (
                 <p className="text-xs text-red-500 mt-1">
@@ -818,7 +818,7 @@ export default function AddUpdateArticleModal({
           {/* Sections Management */}
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <h3 className="text-base font-semibold text-gray-800">
+              <h3 className="text-base font-semibold text-foreground">
                 Konten Section
               </h3>
               <Button
@@ -851,7 +851,7 @@ export default function AddUpdateArticleModal({
                 </Button>
 
                 <div>
-                  <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1.5">
+                  <label className="block text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1.5">
                     Judul Section {index + 1} *
                   </label>
                   <Input
@@ -867,14 +867,14 @@ export default function AddUpdateArticleModal({
                 </div>
 
                 <div>
-                  <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1.5">
+                  <label className="block text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1.5">
                     Isi Konten *
                   </label>
                   <textarea
                     {...register(`sections.${index}.content` as const)}
                     rows={4}
                     placeholder="Tuliskan isi detail section di sini..."
-                    className="w-full px-4 py-3 bg-white border border-[#e5ded5] rounded-xl text-gray-700 placeholder:text-gray-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d] transition-all resize-none"
+                    className="w-full px-4 py-3 bg-white border border-[#e5ded5] rounded-xl text-foreground placeholder:text-muted-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-[#c26a3d]/30 focus-visible:border-[#c26a3d] transition-all resize-none"
                   />
                   {errors.sections?.[index]?.content && (
                     <p className="text-xs text-red-500 mt-1 italic">
@@ -884,7 +884,7 @@ export default function AddUpdateArticleModal({
                 </div>
 
                 <div>
-                  <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1.5">
+                  <label className="block text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-1.5">
                     URL Gambar Section (Opsional)
                   </label>
                   <div className="flex items-start gap-3">
@@ -909,7 +909,7 @@ export default function AddUpdateArticleModal({
                             className="w-20 h-12 object-cover rounded-md"
                           />
                         ) : (
-                          <span className="text-[11px] text-gray-400 text-center">
+                          <span className="text-[11px] text-muted-foreground text-center">
                             No image
                           </span>
                         );
@@ -961,7 +961,7 @@ export default function AddUpdateArticleModal({
             type="button"
             variant="outline"
             onClick={onClose}
-            className="px-6 h-11 bg-white border-[#e5ded5] text-gray-600 hover:bg-gray-50 rounded-xl font-medium transition-colors text-base"
+            className="px-6 h-11 bg-white border-[#e5ded5] text-muted-foreground hover:bg-muted rounded-xl font-medium transition-colors text-base"
           >
             Batal
           </Button>

--- a/src/components/admin/pesanan/admin-order-content.tsx
+++ b/src/components/admin/pesanan/admin-order-content.tsx
@@ -102,7 +102,7 @@ function getOrderStatusBadgeClass(status: OrderStatus) {
       return 'bg-red-100 text-red-700';
     case OrderStatus.pending:
     default:
-      return 'bg-slate-200 text-slate-700';
+      return 'bg-muted text-foreground';
   }
 }
 
@@ -116,7 +116,7 @@ function getPaymentStatusBadgeClass(status: PaymentStatus) {
       return 'bg-orange-100 text-orange-700';
     case PaymentStatus.unpaid:
     default:
-      return 'bg-slate-200 text-slate-700';
+      return 'bg-muted text-foreground';
   }
 }
 

--- a/src/components/admin/product-inventory/add-update-product-modal.tsx
+++ b/src/components/admin/product-inventory/add-update-product-modal.tsx
@@ -242,7 +242,7 @@ export default function AddUpdateProductModal({
         }`}
       >
         <div className="flex items-center justify-between border-b border-[#ebd8c2] px-6 py-4">
-          <h2 className="text-lg font-semibold text-gray-800">
+          <h2 className="text-lg font-semibold text-foreground">
             {isEdit ? 'Edit Produk & Inventori' : 'Tambah Produk Baru'}
           </h2>
           <Button
@@ -250,7 +250,7 @@ export default function AddUpdateProductModal({
             variant="ghost"
             size="icon-sm"
             onClick={onClose}
-            className="rounded-full bg-[#f3ede8] text-gray-500 hover:bg-[#e6dcd5]"
+            className="rounded-full bg-[#f3ede8] text-muted-foreground hover:bg-[#e6dcd5]"
           >
             <X className="size-4" />
           </Button>
@@ -259,7 +259,7 @@ export default function AddUpdateProductModal({
         <div className="custom-scrollbar flex-1 space-y-6 overflow-y-auto px-6 py-5">
           <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
             <div>
-              <label className="mb-1.5 block text-sm font-medium text-gray-600">
+              <label className="mb-1.5 block text-sm font-medium text-muted-foreground">
                 Artikel Terkait *
               </label>
               <Controller
@@ -271,7 +271,7 @@ export default function AddUpdateProductModal({
                     onValueChange={field.onChange}
                     disabled={isLoadingArticles}
                   >
-                    <SelectTrigger className="h-11 w-full rounded-xl border-[#e5ded5] bg-[#fdfaf7] text-gray-700">
+                    <SelectTrigger className="h-11 w-full rounded-xl border-[#e5ded5] bg-[#fdfaf7] text-foreground">
                       <SelectValue
                         placeholder="Pilih artikel"
                         className="block w-full truncate"
@@ -291,12 +291,12 @@ export default function AddUpdateProductModal({
                         </SelectItem>
                       ))}
                       {isFetchingNextArticlePage ? (
-                        <p className="px-2 py-2 text-xs text-gray-500">
+                        <p className="px-2 py-2 text-xs text-muted-foreground">
                           Memuat artikel berikutnya...
                         </p>
                       ) : null}
                       {!hasNextArticlePage && articleOptions.length > 0 ? (
-                        <p className="px-2 py-2 text-xs text-gray-500">
+                        <p className="px-2 py-2 text-xs text-muted-foreground">
                           Semua artikel telah dimuat
                         </p>
                       ) : null}
@@ -312,7 +312,7 @@ export default function AddUpdateProductModal({
             </div>
 
             <div>
-              <label className="mb-1.5 block text-sm font-medium text-gray-600">
+              <label className="mb-1.5 block text-sm font-medium text-muted-foreground">
                 Nama Produk *
               </label>
               <Input
@@ -328,7 +328,7 @@ export default function AddUpdateProductModal({
             </div>
 
             <div>
-              <label className="mb-1.5 block text-sm font-medium text-gray-600">
+              <label className="mb-1.5 block text-sm font-medium text-muted-foreground">
                 Slug Produk *
               </label>
               <Input
@@ -344,7 +344,7 @@ export default function AddUpdateProductModal({
             </div>
 
             <div>
-              <label className="mb-1.5 block text-sm font-medium text-gray-600">
+              <label className="mb-1.5 block text-sm font-medium text-muted-foreground">
                 SKU Produk *
               </label>
               <Input
@@ -360,7 +360,7 @@ export default function AddUpdateProductModal({
             </div>
 
             <div>
-              <label className="mb-1.5 block text-sm font-medium text-gray-600">
+              <label className="mb-1.5 block text-sm font-medium text-muted-foreground">
                 Harga *
               </label>
               <Input
@@ -378,7 +378,7 @@ export default function AddUpdateProductModal({
             </div>
 
             <div>
-              <label className="mb-1.5 block text-sm font-medium text-gray-600">
+              <label className="mb-1.5 block text-sm font-medium text-muted-foreground">
                 Berat (gram) *
               </label>
               <Input
@@ -396,7 +396,7 @@ export default function AddUpdateProductModal({
             </div>
 
             <div>
-              <label className="mb-1.5 block text-sm font-medium text-gray-600">
+              <label className="mb-1.5 block text-sm font-medium text-muted-foreground">
                 Jenis Pakaian *
               </label>
               <Input
@@ -412,7 +412,7 @@ export default function AddUpdateProductModal({
             </div>
 
             <div>
-              <label className="mb-1.5 block text-sm font-medium text-gray-600">
+              <label className="mb-1.5 block text-sm font-medium text-muted-foreground">
                 Gender *
               </label>
               <Controller
@@ -420,7 +420,7 @@ export default function AddUpdateProductModal({
                 name="gender"
                 render={({ field }) => (
                   <Select value={field.value} onValueChange={field.onChange}>
-                    <SelectTrigger className="h-11 rounded-xl border-[#e5ded5] bg-[#fdfaf7] text-gray-700">
+                    <SelectTrigger className="h-11 rounded-xl border-[#e5ded5] bg-[#fdfaf7] text-foreground">
                       <SelectValue placeholder="Pilih gender" />
                     </SelectTrigger>
                     <SelectContent>
@@ -441,7 +441,7 @@ export default function AddUpdateProductModal({
             </div>
 
             <div>
-              <label className="mb-1.5 block text-sm font-medium text-gray-600">
+              <label className="mb-1.5 block text-sm font-medium text-muted-foreground">
                 Status Produk *
               </label>
               <Controller
@@ -449,7 +449,7 @@ export default function AddUpdateProductModal({
                 name="status"
                 render={({ field }) => (
                   <Select value={field.value} onValueChange={field.onChange}>
-                    <SelectTrigger className="h-11 rounded-xl border-[#e5ded5] bg-[#fdfaf7] text-gray-700">
+                    <SelectTrigger className="h-11 rounded-xl border-[#e5ded5] bg-[#fdfaf7] text-foreground">
                       <SelectValue placeholder="Pilih status" />
                     </SelectTrigger>
                     <SelectContent>
@@ -471,7 +471,7 @@ export default function AddUpdateProductModal({
           </div>
 
           <div>
-            <label className="mb-1.5 block text-sm font-medium text-gray-600">
+            <label className="mb-1.5 block text-sm font-medium text-muted-foreground">
               URL Gambar Produk (Opsional)
             </label>
             <Input
@@ -487,14 +487,14 @@ export default function AddUpdateProductModal({
           </div>
 
           <div>
-            <label className="mb-1.5 block text-sm font-medium text-gray-600">
+            <label className="mb-1.5 block text-sm font-medium text-muted-foreground">
               Deskripsi (Opsional)
             </label>
             <textarea
               {...register('description')}
               rows={3}
               placeholder="Deskripsi singkat produk..."
-              className="w-full rounded-xl border border-[#e5ded5] bg-[#fdfaf7] px-4 py-3 text-gray-700 placeholder:text-gray-400 focus-visible:border-[#c26a3d] focus-visible:ring-2 focus-visible:ring-[#c26a3d]/30 focus-visible:outline-none"
+              className="w-full rounded-xl border border-[#e5ded5] bg-[#fdfaf7] px-4 py-3 text-foreground placeholder:text-muted-foreground focus-visible:border-[#c26a3d] focus-visible:ring-2 focus-visible:ring-[#c26a3d]/30 focus-visible:outline-none"
             />
           </div>
 
@@ -502,7 +502,7 @@ export default function AddUpdateProductModal({
 
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <h3 className="text-base font-semibold text-gray-800">
+              <h3 className="text-base font-semibold text-foreground">
                 Varian Produk
               </h3>
               <Button
@@ -550,7 +550,7 @@ export default function AddUpdateProductModal({
 
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                   <div>
-                    <label className="mb-1.5 block text-xs font-semibold tracking-wider text-gray-500 uppercase">
+                    <label className="mb-1.5 block text-xs font-semibold tracking-wider text-muted-foreground uppercase">
                       Nama Varian *
                     </label>
                     <Input
@@ -565,7 +565,7 @@ export default function AddUpdateProductModal({
                   </div>
 
                   <div>
-                    <label className="mb-1.5 block text-xs font-semibold tracking-wider text-gray-500 uppercase">
+                    <label className="mb-1.5 block text-xs font-semibold tracking-wider text-muted-foreground uppercase">
                       Tipe Varian *
                     </label>
                     <Controller
@@ -576,7 +576,7 @@ export default function AddUpdateProductModal({
                           value={variantField.value}
                           onValueChange={variantField.onChange}
                         >
-                          <SelectTrigger className="h-10 bg-white text-gray-700">
+                          <SelectTrigger className="h-10 bg-white text-foreground">
                             <SelectValue placeholder="Pilih tipe varian" />
                           </SelectTrigger>
                           <SelectContent>
@@ -600,7 +600,7 @@ export default function AddUpdateProductModal({
                   </div>
 
                   <div>
-                    <label className="mb-1.5 block text-xs font-semibold tracking-wider text-gray-500 uppercase">
+                    <label className="mb-1.5 block text-xs font-semibold tracking-wider text-muted-foreground uppercase">
                       SKU Varian *
                     </label>
                     <Input
@@ -615,7 +615,7 @@ export default function AddUpdateProductModal({
                   </div>
 
                   <div>
-                    <label className="mb-1.5 block text-xs font-semibold tracking-wider text-gray-500 uppercase">
+                    <label className="mb-1.5 block text-xs font-semibold tracking-wider text-muted-foreground uppercase">
                       Stok Varian *
                     </label>
                     <Input
@@ -634,7 +634,7 @@ export default function AddUpdateProductModal({
                   </div>
 
                   <div className="md:col-span-2">
-                    <label className="mb-1.5 block text-xs font-semibold tracking-wider text-gray-500 uppercase">
+                    <label className="mb-1.5 block text-xs font-semibold tracking-wider text-muted-foreground uppercase">
                       URL Gambar Varian (Opsional)
                     </label>
                     <Input
@@ -649,7 +649,7 @@ export default function AddUpdateProductModal({
                   </div>
 
                   <div className="md:col-span-2">
-                    <label className="mb-1.5 block text-xs font-semibold tracking-wider text-gray-500 uppercase">
+                    <label className="mb-1.5 block text-xs font-semibold tracking-wider text-muted-foreground uppercase">
                       Harga Varian *
                     </label>
                     <Controller
@@ -675,7 +675,7 @@ export default function AddUpdateProductModal({
                         />
                       )}
                     />
-                    <p className="mt-1 text-xs text-gray-500">
+                    <p className="mt-1 text-xs text-muted-foreground">
                       Harga ini adalah harga jual langsung untuk varian, bukan
                       tambahan dari harga produk utama.
                     </p>
@@ -707,7 +707,7 @@ export default function AddUpdateProductModal({
             type="button"
             variant="outline"
             onClick={onClose}
-            className="h-11 rounded-xl border-[#e5ded5] bg-white px-6 text-base text-gray-600 hover:bg-gray-50"
+            className="h-11 rounded-xl border-[#e5ded5] bg-white px-6 text-base text-muted-foreground hover:bg-muted"
           >
             Batal
           </Button>

--- a/src/components/admin/product-inventory/admin-product-inventory-content.tsx
+++ b/src/components/admin/product-inventory/admin-product-inventory-content.tsx
@@ -63,11 +63,11 @@ function getStatusBadgeClass(status: ProductInventoryItem['status']) {
     case 'active':
       return 'bg-emerald-100 text-emerald-700';
     case 'inactive':
-      return 'bg-slate-200 text-slate-700';
+      return 'bg-muted text-foreground';
     case 'out_of_stock':
       return 'bg-red-100 text-red-700';
     default:
-      return 'bg-slate-200 text-slate-700';
+      return 'bg-muted text-foreground';
   }
 }
 

--- a/src/components/catalog/detail/catalog-detail-main.tsx
+++ b/src/components/catalog/detail/catalog-detail-main.tsx
@@ -290,6 +290,10 @@ export function CatalogDetailMain({ slug }: { slug: string }) {
         return;
       }
 
+      const selectedVariant = selectedVariantId
+        ? product.variants.find((variant) => variant.id === selectedVariantId)
+        : undefined;
+
       setCheckoutSession({
         items: [
           {
@@ -301,6 +305,7 @@ export function CatalogDetailMain({ slug }: { slug: string }) {
               effectiveSelectedSize ?? effectiveSelectedColor ?? 'Default',
             price: selectedVariantPrice,
             quantity: safeQuantity,
+            imageURL: selectedVariant?.imageURL ?? product.imageURL,
           },
         ],
         createdAt: new Date().toISOString(),

--- a/src/components/checkout/checkout-summary.tsx
+++ b/src/components/checkout/checkout-summary.tsx
@@ -28,12 +28,12 @@ export function CheckoutSummary({ totals, items = [] }: CheckoutSummaryProps) {
     return (
       <div className="bg-white rounded-2xl border border-[#e8e2d5] p-6 shadow-sm animate-pulse h-[400px]">
         <div className="flex justify-between mb-6">
-          <div className="h-4 bg-gray-200 rounded w-1/2"></div>
-          <div className="h-4 bg-gray-200 rounded w-1/4"></div>
+          <div className="h-4 bg-muted rounded w-1/2"></div>
+          <div className="h-4 bg-muted rounded w-1/4"></div>
         </div>
         <div className="space-y-4">
-          <div className="h-12 bg-gray-100 rounded"></div>
-          <div className="h-12 bg-gray-100 rounded"></div>
+          <div className="h-12 bg-muted rounded"></div>
+          <div className="h-12 bg-muted rounded"></div>
         </div>
       </div>
     );

--- a/src/components/encyclopedia/encyclopedia-article-card.tsx
+++ b/src/components/encyclopedia/encyclopedia-article-card.tsx
@@ -15,18 +15,18 @@ export function EncyclopediaArticleCard({
 }: EncyclopediaArticleCardProps) {
   return (
     <Card
-      className="cursor-pointer overflow-hidden rounded-2xl border border-[#d8cfbf] bg-[#fbf8f2] shadow-sm transition-shadow hover:shadow-md"
+      className="group cursor-pointer overflow-hidden rounded-2xl border border-[#d8cfbf] bg-[#fbf8f2] shadow-sm transition-all duration-300 ease-out hover:-translate-y-1 hover:border-[#c0b39a] hover:shadow-[0_22px_42px_-26px_rgba(47,91,73,0.55)]"
       onClick={() => onClick?.(article)}
     >
       {/* Image Placeholder */}
-      <div className="relative h-44 border-b border-dashed border-[#ded3c1] bg-[#ece1d0]">
+      <div className="relative h-44 overflow-hidden border-b border-dashed border-[#ded3c1] bg-[#ece1d0]">
         {article.imageURL ? (
           <Image
             src={article.imageURL}
             alt={article.title}
             fill
             unoptimized
-            className="object-cover"
+            className="object-cover transition duration-700 ease-out group-hover:scale-110"
           />
         ) : (
           <div className="absolute inset-0 grid place-items-center">
@@ -55,7 +55,7 @@ export function EncyclopediaArticleCard({
           </Badge>
         </div>
 
-        <h3 className="mt-2 line-clamp-2 text-2xl font-bold leading-tight text-[#315746]">
+        <h3 className="mt-2 line-clamp-2 text-2xl font-bold leading-tight text-[#315746] transition-colors duration-300 group-hover:text-[#2f5f49]">
           {article.title}
         </h3>
 

--- a/src/components/encyclopedia/encyclopedia-article-list-card.tsx
+++ b/src/components/encyclopedia/encyclopedia-article-list-card.tsx
@@ -15,7 +15,7 @@ export function EncyclopediaArticleListCard({
 }: EncyclopediaArticleListCardProps) {
   return (
     <Card
-      className="cursor-pointer overflow-hidden rounded-2xl border border-[#d8cfbf] bg-[#fbf8f2] shadow-sm transition-shadow hover:shadow-md"
+      className="group cursor-pointer overflow-hidden rounded-2xl border border-[#d8cfbf] bg-[#fbf8f2] shadow-sm transition-all duration-300 ease-out hover:-translate-y-0.5 hover:border-[#c0b39a] hover:shadow-[0_18px_36px_-26px_rgba(47,91,73,0.55)]"
       onClick={() => onClick?.(article)}
     >
       <div className="flex items-start gap-4 p-4">
@@ -28,7 +28,7 @@ export function EncyclopediaArticleListCard({
               fill
               unoptimized
               sizes="128px"
-              className="object-cover object-center"
+              className="object-cover object-center transition duration-700 ease-out group-hover:scale-110"
             />
           ) : (
             <div className="flex h-full items-center justify-center">
@@ -59,7 +59,7 @@ export function EncyclopediaArticleListCard({
             </Badge>
           </div>
 
-          <h3 className="mt-2 line-clamp-2 text-lg font-bold leading-tight text-[#315746]">
+          <h3 className="mt-2 line-clamp-2 text-lg font-bold leading-tight text-[#315746] transition-colors duration-300 group-hover:text-[#2f5f49]">
             {article.title}
           </h3>
 

--- a/src/components/encyclopedia/encyclopedia-featured-card.tsx
+++ b/src/components/encyclopedia/encyclopedia-featured-card.tsx
@@ -18,7 +18,7 @@ export function EncyclopediaFeaturedCard({
 }: EncyclopediaFeaturedCardProps) {
   if (viewMode === 'list') {
     return (
-      <Card className="overflow-hidden rounded-2xl border border-[#d5ccbc] bg-[#faf8f2]">
+      <Card className="group overflow-hidden rounded-2xl border border-[#d5ccbc] bg-[#faf8f2] transition-all duration-300 ease-out hover:-translate-y-0.5 hover:border-[#c0b39a] hover:shadow-[0_18px_36px_-26px_rgba(47,91,73,0.55)]">
         <div className="flex items-start gap-4 p-4">
           {/* Image */}
           <div className="relative h-32 w-32 flex-shrink-0 overflow-hidden rounded-xl border border-dashed border-[#ded3c1] bg-[#ece1d0]">
@@ -29,7 +29,7 @@ export function EncyclopediaFeaturedCard({
                 fill
                 unoptimized
                 sizes="128px"
-                className="object-cover object-center"
+                className="object-cover object-center transition duration-700 ease-out group-hover:scale-110"
               />
             ) : (
               <div className="flex h-full items-center justify-center">
@@ -88,16 +88,16 @@ export function EncyclopediaFeaturedCard({
   }
 
   return (
-    <Card className="overflow-hidden rounded-2xl border border-[#d5ccbc] bg-[#faf8f2]">
+    <Card className="group overflow-hidden rounded-2xl border border-[#d5ccbc] bg-[#faf8f2] transition-all duration-300 ease-out hover:-translate-y-0.5 hover:border-[#c0b39a] hover:shadow-[0_26px_52px_-30px_rgba(47,91,73,0.55)]">
       <div className="grid md:grid-cols-[320px_minmax(0,1fr)]">
         {/* Image Placeholder */}
-        <div className="relative min-h-[185px] border-b border-dashed border-[#dacfbf] bg-[#ece1d0] md:min-h-[220px] md:border-b-0 md:border-r">
+        <div className="relative min-h-[185px] overflow-hidden border-b border-dashed border-[#dacfbf] bg-[#ece1d0] md:min-h-[220px] md:border-b-0 md:border-r">
           {article.imageURL ? (
             <Image
               src={article.imageURL}
               alt={article.title}
               fill
-              className="object-cover"
+              className="object-cover transition duration-700 ease-out group-hover:scale-105"
             />
           ) : (
             <div className="absolute inset-0 grid place-items-center">
@@ -155,11 +155,11 @@ export function EncyclopediaFeaturedCard({
 
           <Button
             variant="outline"
-            className="mt-4 inline-flex items-center gap-1 rounded-xl border-[#98ab9e] px-4 py-2 text-sm font-bold text-[#2f5f49] transition hover:bg-[#edf2ea]"
+            className="group/btn mt-4 inline-flex items-center gap-1 rounded-xl border-[#98ab9e] px-4 py-2 text-sm font-bold text-[#2f5f49] transition hover:border-[#2f5f49] hover:bg-[#2f5f49] hover:text-[#edf3e8] active:scale-95"
             onClick={() => onReadMore?.(article)}
           >
             Baca Selengkapnya
-            <ArrowRight className="h-4 w-4" />
+            <ArrowRight className="h-4 w-4 transition-transform duration-300 group-hover/btn:translate-x-1" />
           </Button>
         </div>
       </div>

--- a/src/components/encyclopedia/encyclopedia-main.tsx
+++ b/src/components/encyclopedia/encyclopedia-main.tsx
@@ -34,11 +34,17 @@ interface EncyclopediaMainProps {
 
 function EncyclopediaStatsSkeleton() {
   return (
-    <div className="mt-7 grid grid-cols-3 gap-4 border-y border-[#d8d0c1] py-5">
-      {Array.from({ length: 3 }).map((_, index) => (
-        <div key={index} className="flex flex-col gap-2">
-          <Skeleton className="h-10 w-20 bg-[#e6dfd1]" />
-          <Skeleton className="h-4 w-28 bg-[#e6dfd1]" />
+    <div className="mt-7 grid grid-cols-2 gap-3 border-t border-[#d8d0c1] pt-5 sm:grid-cols-4">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <div
+          key={index}
+          className="flex items-center gap-3 rounded-xl border border-[#ddd3c2] bg-[#f7f3ea]/70 px-4 py-3"
+        >
+          <Skeleton className="h-10 w-10 shrink-0 rounded-lg bg-[#e6dfd1]" />
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-6 w-10 bg-[#e6dfd1]" />
+            <Skeleton className="h-3 w-24 bg-[#e6dfd1]" />
+          </div>
         </div>
       ))}
     </div>
@@ -239,9 +245,10 @@ export function EncyclopediaMain({
                 </BreadcrumbItem>
               </BreadcrumbList>
             </Breadcrumb>
-            <h1 className="mt-2 text-3xl font-medium tracking-tight text-[#2f5b49]">
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-[#2f5b49]">
               Ensiklopedia Budaya Wastra
             </h1>
+            <div className="mt-3 h-1 w-16 rounded-full bg-gradient-to-r from-[#2f5b49] to-[#caa86a]" />
             <p className="mt-3 text-sm max-w-2xl text-medium leading-relaxed text-[#4d6759]">
               Jelajahi kekayaan pengetahuan wastra tradisional Indonesia dari
               teknik tenun hingga makna filosofi setiap motif kain.
@@ -294,7 +301,7 @@ export function EncyclopediaMain({
                     <Button
                       variant="ghost"
                       size="sm"
-                      className={`h-8 w-8 p-0 transition ${
+                      className={`h-8 w-8 p-0 transition-all active:scale-90 ${
                         viewMode === 'grid'
                           ? 'bg-[#2f5f49] text-[#eef3ea] hover:bg-[#2f5f49]/90 hover:text-[#eef3ea]'
                           : 'text-[#4c6457] hover:bg-[#ece5d8]'
@@ -307,7 +314,7 @@ export function EncyclopediaMain({
                     <Button
                       variant="ghost"
                       size="sm"
-                      className={`h-8 w-8 p-0  transition ${
+                      className={`h-8 w-8 p-0 transition-all active:scale-90 ${
                         viewMode === 'list'
                           ? 'bg-[#2f5f49] text-[#eef3ea] hover:bg-[#2f5f49]/90 hover:text-[#eef3ea]'
                           : 'text-[#4c6457] hover:bg-[#ece5d8]'

--- a/src/components/encyclopedia/encyclopedia-search-results.tsx
+++ b/src/components/encyclopedia/encyclopedia-search-results.tsx
@@ -75,7 +75,7 @@ export function EncyclopediaSearchResults({
   return (
     <div ref={containerRef} className="relative w-full">
       {/* Search Input */}
-      <div className="flex items-center overflow-hidden rounded-xl border border-[#ddd3c2] bg-[#f3ede2]">
+      <div className="flex items-center overflow-hidden rounded-xl border border-[#ddd3c2] bg-[#f3ede2] transition-all duration-300 focus-within:border-[#2f5b49]/40 focus-within:bg-white focus-within:shadow-[0_0_0_4px_rgba(47,91,73,0.08)]">
         <Search className="ml-4 h-4 w-4 text-[#9f9a8d]" />
         <Input
           className="h-12 w-full border-0 bg-transparent px-3 text-sm text-[#445f50] placeholder:text-[#b2ad9f] focus-visible:ring-0 focus-visible:ring-offset-0"

--- a/src/components/encyclopedia/encyclopedia-sidebar.tsx
+++ b/src/components/encyclopedia/encyclopedia-sidebar.tsx
@@ -57,10 +57,10 @@ export function EncyclopediaSidebar({
             <li key={island.name}>
               <Button
                 variant="ghost"
-                className={`flex h-auto w-full items-center justify-between rounded-md px-3 py-2 text-sm font-medium transition ${
+                className={`flex h-auto w-full items-center justify-between rounded-md px-3 py-2 text-sm font-medium transition-all duration-200 ${
                   island.active
-                    ? 'bg-[#2f5f49] text-[#eef3ea] hover:bg-[#2f5f49]/90 hover:text-[#eef3ea]'
-                    : 'text-[#4c6457] hover:bg-[#ece5d8]'
+                    ? 'bg-[#2f5f49] text-[#eef3ea] shadow-sm hover:bg-[#2f5f49]/90 hover:text-[#eef3ea]'
+                    : 'text-[#4c6457] hover:translate-x-0.5 hover:bg-[#ece5d8]'
                 }`}
                 onClick={() => onIslandClick?.(island.name)}
               >
@@ -110,10 +110,10 @@ export function EncyclopediaSidebar({
               key={topic}
               variant="outline"
               size="sm"
-              className={`h-auto rounded-md border-[#d8cfbf] px-2.5 py-1 text-xs font-semibold transition ${
+              className={`h-auto rounded-md border-[#d8cfbf] px-2.5 py-1 text-xs font-semibold transition-all duration-200 hover:scale-105 active:scale-95 ${
                 selectedTopic === topic
-                  ? 'bg-[#2f5f49] text-[#eef3ea] hover:bg-[#2f5f49]/90 hover:text-[#eef3ea]'
-                  : 'bg-[#efeadf] text-[#5d6f62] hover:bg-[#e4decf]'
+                  ? 'bg-[#2f5f49] text-[#eef3ea] shadow-sm hover:bg-[#2f5f49]/90 hover:text-[#eef3ea]'
+                  : 'bg-[#efeadf] text-[#5d6f62] hover:border-[#bfae8e] hover:bg-[#e4decf]'
               }`}
               onClick={() => onTopicClick?.(topic)}
             >
@@ -126,7 +126,7 @@ export function EncyclopediaSidebar({
       {/* Reset Button */}
       <Button
         variant="outline"
-        className="w-full rounded-xl border-[#d4cbbc] bg-[#f7f3ea] px-4 py-2 text-sm font-bold text-[#5d6f62] transition hover:bg-[#eee8db]"
+        className="w-full rounded-xl border-[#d4cbbc] bg-[#f7f3ea] px-4 py-2 text-sm font-bold text-[#5d6f62] transition-all duration-200 hover:border-[#c0b39a] hover:bg-[#eee8db] hover:shadow-sm active:scale-[0.99]"
         onClick={onResetFilters}
       >
         Reset Semua Filter

--- a/src/components/encyclopedia/encyclopedia-stats.tsx
+++ b/src/components/encyclopedia/encyclopedia-stats.tsx
@@ -1,22 +1,42 @@
-﻿import type { Stat } from '@/types/encyclopedia';
+import type { Stat } from '@/types/encyclopedia';
+import { BookOpen, Layers, type LucideIcon, Map, MapPin } from 'lucide-react';
 
 interface EncyclopediaStatsProps {
   stats: Stat[];
 }
 
+const STAT_ICONS: Record<string, LucideIcon> = {
+  'Total Artikel': BookOpen,
+  'Pulau Tercakup': Map,
+  'Provinsi Tercakup': MapPin,
+  'Jenis Wastra': Layers,
+};
+
 export function EncyclopediaStats({ stats }: EncyclopediaStatsProps) {
   return (
-    <div className="mt-7 flex gap-3 border-t border-[#d8d0c1] py-5">
-      {stats.map((stat) => (
-        <div key={stat.label} className="text-center">
-          <p className="text-xl font-extrabold leading-none tracking-tight text-[#2f5b49]">
-            {stat.value}
-          </p>
-          <p className="mt-1.5 text-xs font-medium text-[#586f62]">
-            {stat.label}
-          </p>
-        </div>
-      ))}
+    <div className="mt-7 grid grid-cols-2 gap-3 border-t border-[#d8d0c1] pt-5 sm:grid-cols-4">
+      {stats.map((stat) => {
+        const Icon = STAT_ICONS[stat.label] ?? BookOpen;
+
+        return (
+          <div
+            key={stat.label}
+            className="group flex items-center gap-3 rounded-xl border border-[#ddd3c2] bg-[#f7f3ea]/70 px-4 py-3 transition-all duration-300 ease-out hover:-translate-y-0.5 hover:border-[#c7b59b] hover:bg-[#f7f3ea] hover:shadow-[0_14px_28px_-20px_rgba(47,91,73,0.6)]"
+          >
+            <span className="grid h-10 w-10 shrink-0 place-items-center rounded-lg bg-[#2f5b49]/10 text-[#2f5b49] transition-colors duration-300 group-hover:bg-[#2f5b49] group-hover:text-[#f3ede2]">
+              <Icon className="h-5 w-5" />
+            </span>
+            <div>
+              <p className="text-2xl font-extrabold leading-none tracking-tight text-[#2f5b49]">
+                {stat.value}
+              </p>
+              <p className="mt-1.5 text-xs font-medium text-[#586f62]">
+                {stat.label}
+              </p>
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/landing-page/category-filter.tsx
+++ b/src/components/landing-page/category-filter.tsx
@@ -19,7 +19,7 @@ export function CategoryFilter() {
               key={category}
               asChild
               variant="outline"
-              className="rounded-full border border-[#4a3a2a]/[14.5%] bg-[#4a3a2a]/[6.3%] px-4 py-1.5 text-sm font-medium text-[#2f4f3f] transition hover:border-[#2f4f3f] hover:text-white hover:bg-[#2f4f3f]"
+              className="rounded-full border border-[#4a3a2a]/[14.5%] bg-[#4a3a2a]/[6.3%] px-4 py-1.5 text-sm font-medium text-[#2f4f3f] transition-all hover:-translate-y-0.5 hover:border-[#2f4f3f] hover:bg-[#2f4f3f] hover:text-white hover:shadow-sm active:scale-95"
             >
               <Link href={`/catalog?topic=${encodeURIComponent(category)}`}>
                 {category}

--- a/src/components/landing-page/encyclopedia-section.tsx
+++ b/src/components/landing-page/encyclopedia-section.tsx
@@ -97,7 +97,7 @@ export function EncyclopediaSection() {
               keunikan motif, bahan, dan makna simbolis yang mendalam.
             </p>
 
-            <div className="mt-5 flex max-w-xl items-center overflow-hidden rounded-xl border border-white/15 bg-[#254d3a]">
+            <div className="mt-5 flex max-w-xl items-center overflow-hidden rounded-xl border border-white/15 bg-[#254d3a] transition-all duration-300 focus-within:border-white/35 focus-within:bg-[#21473590] focus-within:shadow-[0_0_0_4px_rgba(213,200,179,0.12)]">
               <Search className="ml-4 h-4 w-4 text-[#b7cdbf]" />
               <Input
                 className="h-12 w-full border-0 bg-transparent px-3 text-sm text-[#ebf3e7] placeholder:text-[#95b19f] focus-visible:ring-0 focus-visible:ring-offset-0"
@@ -106,7 +106,7 @@ export function EncyclopediaSection() {
               />
               <Button
                 asChild
-                className="inline-flex h-12 items-center bg-[#d5c8b3] px-6 text-sm font-bold text-[#2d5f48] transition hover:bg-[#e6dccc]"
+                className="inline-flex h-12 items-center bg-[#d5c8b3] px-6 text-sm font-bold text-[#2d5f48] transition hover:bg-[#e6dccc] active:scale-95"
               >
                 <Link href="/encyclopedia">Cari</Link>
               </Button>
@@ -118,7 +118,7 @@ export function EncyclopediaSection() {
                 <Button
                   key={tag.name}
                   asChild
-                  className="rounded-full border border-white/18 bg-white/8 px-3 py-1.5 font-semibold text-[#d2dfd2] transition hover:bg-white/14"
+                  className="rounded-full border border-white/18 bg-white/8 px-3 py-1.5 font-semibold text-[#d2dfd2] transition hover:scale-105 hover:border-white/35 hover:bg-white/14 active:scale-95"
                 >
                   <Link
                     href={`/encyclopedia?island=${encodeURIComponent(tag.name)}`}
@@ -135,7 +135,7 @@ export function EncyclopediaSection() {
                 <Button
                   key={topic}
                   asChild
-                  className="rounded-full border border-white/18 bg-white/8 px-3 py-1.5 font-semibold text-[#d2dfd2] transition hover:bg-white/14"
+                  className="rounded-full border border-white/18 bg-white/8 px-3 py-1.5 font-semibold text-[#d2dfd2] transition hover:scale-105 hover:border-white/35 hover:bg-white/14 active:scale-95"
                 >
                   <Link
                     href={`/encyclopedia?topic=${encodeURIComponent(topic)}`}
@@ -206,7 +206,7 @@ export function EncyclopediaSection() {
                       href={`/encyclopedia/${article.slug}`}
                       className="block"
                     >
-                      <Card className="rounded-2xl border border-white/6 bg-white/7 p-4 transition hover:bg-white/11">
+                      <Card className="group rounded-2xl border border-white/6 bg-white/7 p-4 transition-all duration-300 ease-out hover:-translate-y-0.5 hover:border-white/20 hover:bg-white/11">
                         <div className="flex items-center gap-4">
                           <div className="relative h-20 w-20 flex-shrink-0 overflow-hidden rounded-lg border-2 border-dashed border-white/10 bg-[radial-gradient(circle_at_35%_35%,rgba(248,234,210,.18)_0%,rgba(214,183,145,.2)_55%,rgba(138,110,77,.3)_100%)]">
                             {article.imageURL ? (
@@ -214,7 +214,7 @@ export function EncyclopediaSection() {
                                 src={article.imageURL}
                                 alt={article.title}
                                 fill
-                                className="object-cover"
+                                className="object-cover transition duration-500 ease-out group-hover:scale-110"
                                 sizes="80px"
                               />
                             ) : (
@@ -252,11 +252,11 @@ export function EncyclopediaSection() {
 
             <Button
               asChild
-              className="mt-5 inline-flex items-center gap-1 text-sm font-semibold text-[#d4e1d2] transition hover:text-white"
+              className="group mt-5 inline-flex items-center gap-1 text-sm font-semibold text-[#d4e1d2] transition hover:text-white"
             >
               <Link href="/encyclopedia">
                 Lihat semua artikel
-                <ChevronRight className="h-4 w-4" />
+                <ChevronRight className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
               </Link>
             </Button>
           </aside>

--- a/src/components/landing-page/featured-cards.tsx
+++ b/src/components/landing-page/featured-cards.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useArticles } from '@/hooks/use-article';
+import { ArrowUpRight } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -64,14 +65,14 @@ export function FeaturedCards() {
       {!isPending && !error && featuredArticles.length > 0
         ? featuredArticles.map((article, index) => (
             <Link key={article.slug} href={`/encyclopedia/${article.slug}`}>
-              <Card className="group relative overflow-hidden rounded-2xl border border-[#ddd5c6] bg-[#5a453a] shadow-sm">
+              <Card className="group relative overflow-hidden rounded-2xl border border-[#ddd5c6] bg-[#5a453a] shadow-sm transition-all duration-500 ease-out hover:-translate-y-1 hover:border-[#c7b59b] hover:shadow-[0_22px_42px_-24px_rgba(45,95,72,0.6)]">
                 <div className="absolute inset-0">
                   {article.imageURL ? (
                     <Image
                       src={article.imageURL}
                       alt={article.title}
                       fill
-                      className="object-cover transition duration-500 group-hover:scale-105"
+                      className="object-cover transition duration-700 ease-out group-hover:scale-110"
                       sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
                     />
                   ) : null}
@@ -81,9 +82,13 @@ export function FeaturedCards() {
                 />
                 <div className="absolute inset-0 bg-[radial-gradient(circle_at_78%_26%,rgba(249,229,193,.28)_0%,rgba(0,0,0,0)_36%)]" />
 
+                <span className="absolute right-4 top-4 z-10 grid h-9 w-9 translate-y-1 place-items-center rounded-full border border-white/25 bg-black/30 text-[#f6eee1] opacity-0 backdrop-blur transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100">
+                  <ArrowUpRight className="h-4 w-4" />
+                </span>
+
                 <div className="relative flex min-h-[225px] items-end p-4">
-                  <div>
-                    <Badge className="mb-3 rounded-md bg-white/14 px-2.5 py-1 text-[11px] font-semibold text-[#f6eee1] backdrop-blur-sm">
+                  <div className="transition-transform duration-500 ease-out group-hover:-translate-y-0.5">
+                    <Badge className="mb-3 rounded-md bg-white/14 px-2.5 py-1 text-[11px] font-semibold text-[#f6eee1] backdrop-blur-sm transition-colors group-hover:bg-white/24">
                       {article.topic}
                     </Badge>
                     <p className="text-lg font-semibold leading-tight text-[#f6eee1]">

--- a/src/components/landing-page/hero-section.tsx
+++ b/src/components/landing-page/hero-section.tsx
@@ -211,7 +211,7 @@ export function HeroSection() {
                         <Button
                           asChild
                           variant="outline"
-                          className="rounded-xl bg-[#d7ccb7] px-5 py-2.5 text-sm font-bold text-[#2c503f] transition hover:bg-[#2d5f48] hover:text-white hover:border-[#2d5f48]"
+                          className="rounded-xl bg-[#d7ccb7] px-5 py-2.5 text-sm font-bold text-[#2c503f] transition hover:-translate-y-0.5 hover:border-[#2d5f48] hover:bg-[#2d5f48] hover:text-white hover:shadow-lg active:scale-95"
                         >
                           <Link href={`/encyclopedia/${slide.slug}`}>
                             Baca Artikel
@@ -219,7 +219,7 @@ export function HeroSection() {
                         </Button>
                         <Button
                           asChild
-                          className="rounded-xl border border-[#c7b59b] bg-white/10 px-5 py-2.5 text-sm font-semibold text-[#f8f3e9] transition hover:bg-white/15"
+                          className="rounded-xl border border-[#c7b59b] bg-white/10 px-5 py-2.5 text-sm font-semibold text-[#f8f3e9] transition hover:-translate-y-0.5 hover:bg-white/20 active:scale-95"
                         >
                           <Link href="/encyclopedia">
                             Jelajahi Ensiklopedia
@@ -242,14 +242,14 @@ export function HeroSection() {
         {activeSlide + 1} / {slides.length}
       </Badge>
       <Button
-        className="absolute left-5 top-1/2 z-20 grid h-10 w-10 -translate-y-1/2 place-items-center rounded-full border border-white/20 bg-white/12 text-[#efe9db] backdrop-blur transition hover:bg-white/20"
+        className="absolute left-5 top-1/2 z-20 grid h-10 w-10 -translate-y-1/2 place-items-center rounded-full border border-white/20 bg-white/12 text-[#efe9db] backdrop-blur transition hover:scale-110 hover:bg-white/25 active:scale-95"
         type="button"
         onClick={goToPreviousSlide}
       >
         <ChevronLeft className="h-4 w-4" />
       </Button>
       <Button
-        className="absolute right-5 top-1/2 z-20 grid h-10 w-10 -translate-y-1/2 place-items-center rounded-full border border-white/20 bg-white/12 text-[#efe9db] backdrop-blur transition hover:bg-white/20"
+        className="absolute right-5 top-1/2 z-20 grid h-10 w-10 -translate-y-1/2 place-items-center rounded-full border border-white/20 bg-white/12 text-[#efe9db] backdrop-blur transition hover:scale-110 hover:bg-white/25 active:scale-95"
         type="button"
         onClick={goToNextSlide}
       >

--- a/src/components/landing-page/island-cards.tsx
+++ b/src/components/landing-page/island-cards.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/ui/carousel';
 import { useArticles } from '@/hooks/use-article';
 import type { EncyclopediaArticle } from '@/types/encyclopedia';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ArrowUpRight, ChevronLeft, ChevronRight } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
@@ -98,7 +98,7 @@ export function IslandCards() {
           >
             <Button
               type="button"
-              className="absolute left-0 top-1/2 z-20 grid size-10 -translate-y-1/2 place-items-center rounded-full border border-[#ddd4c6] bg-white text-[#2d5f48] transition hover:bg-[#f3ecdd]"
+              className="absolute left-0 top-1/2 z-20 grid size-10 -translate-y-1/2 place-items-center rounded-full border border-[#ddd4c6] bg-white text-[#2d5f48] shadow-sm transition hover:bg-[#2d5f48] hover:text-white hover:scale-105 active:scale-95 disabled:opacity-40 disabled:hover:scale-100 disabled:hover:bg-white disabled:hover:text-[#2d5f48]"
               disabled={islands.length <= 5}
               onClick={() => carouselApi?.scrollPrev()}
             >
@@ -106,7 +106,7 @@ export function IslandCards() {
             </Button>
             <Button
               type="button"
-              className="absolute right-0 top-1/2 z-20 grid size-10 -translate-y-1/2 place-items-center rounded-full border border-[#ddd4c6] bg-white text-[#2d5f48] transition hover:bg-[#f3ecdd]"
+              className="absolute right-0 top-1/2 z-20 grid size-10 -translate-y-1/2 place-items-center rounded-full border border-[#ddd4c6] bg-white text-[#2d5f48] shadow-sm transition hover:bg-[#2d5f48] hover:text-white hover:scale-105 active:scale-95 disabled:opacity-40 disabled:hover:scale-100 disabled:hover:bg-white disabled:hover:text-[#2d5f48]"
               disabled={islands.length <= 5}
               onClick={() => carouselApi?.scrollNext()}
             >
@@ -121,18 +121,18 @@ export function IslandCards() {
                   <Link
                     href={`/encyclopedia?island=${encodeURIComponent(island.name)}`}
                   >
-                    <Card className="group relative overflow-hidden rounded-2xl border border-[#ddd4c6]">
+                    <Card className="group relative overflow-hidden rounded-2xl border border-[#ddd4c6] transition-all duration-500 ease-out hover:-translate-y-1 hover:border-[#c7b59b] hover:shadow-[0_22px_42px_-24px_rgba(20,28,22,0.65)]">
                       {islandImages.get(island.name) ? (
                         <Image
                           src={islandImages.get(island.name)!}
                           alt={island.name}
                           fill
                           sizes="(min-width: 1280px) 20vw, (min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
-                          className="object-cover transition duration-500 group-hover:scale-105"
+                          className="object-cover transition duration-700 ease-out group-hover:scale-110"
                         />
                       ) : (
                         <div
-                          className="absolute inset-0 transition duration-500 group-hover:scale-105"
+                          className="absolute inset-0 transition duration-700 ease-out group-hover:scale-110"
                           style={{
                             backgroundImage: getIslandCardBackground(index),
                           }}
@@ -140,11 +140,11 @@ export function IslandCards() {
                       )}
                       <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_top,rgba(0,0,0,0.92)_0%,rgba(0,0,0,0.78)_45%,rgba(0,0,0,0.35)_75%,rgba(0,0,0,0)_100%)]" />
 
-                      <div className="relative flex min-h-[188px] flex-col justify-end p-4 text-[#f6f2e8]">
-                        {/* <span className="mb-2 inline-flex h-4 w-4 rotate-45 border border-[#e9dec8]" />
-                        <p className="text-sm text-[#e5dcca]">
-                          Eksplorasi Pulau
-                        </p> */}
+                      <span className="absolute right-3 top-3 z-10 grid h-8 w-8 translate-y-1 place-items-center rounded-full border border-white/25 bg-black/30 text-[#f6f2e8] opacity-0 backdrop-blur transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100">
+                        <ArrowUpRight className="h-4 w-4" />
+                      </span>
+
+                      <div className="relative flex min-h-[188px] flex-col justify-end p-4 text-[#f6f2e8] transition-transform duration-500 ease-out group-hover:-translate-y-0.5">
                         <p className="mt-2 text-lg font-bold leading-tight">
                           {island.name}
                         </p>

--- a/src/components/landing-page/product-catalog.tsx
+++ b/src/components/landing-page/product-catalog.tsx
@@ -54,11 +54,11 @@ export function ProductCatalog() {
           <Button
             asChild
             variant="outline"
-            className="flex items-center gap-1 rounded-xl border border-[#2f4f3f] bg-[#f6f3eb] px-4 py-2 text-sm font-semibold text-[#2f4f3f] transition hover:border-[#2f4f3f] hover:bg-[#2d5f48] hover:text-white"
+            className="group flex items-center gap-1 rounded-xl border border-[#2f4f3f] bg-[#f6f3eb] px-4 py-2 text-sm font-semibold text-[#2f4f3f] transition hover:border-[#2f4f3f] hover:bg-[#2d5f48] hover:text-white active:scale-95"
           >
             <Link href="/catalog">
               Lihat Semua
-              <ChevronRight className="h-4 w-4" />
+              <ChevronRight className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
             </Link>
           </Button>
         </div>
@@ -68,10 +68,10 @@ export function ProductCatalog() {
           {SORT_OPTIONS.map((option) => (
             <Button
               key={option.value}
-              className={`rounded-md border px-3 py-1.5 text-xs font-semibold transition ${
+              className={`rounded-md border px-3 py-1.5 text-xs font-semibold transition active:scale-95 ${
                 activeSort === option.value
-                  ? 'border-[#2d5f48] bg-[#2d5f48] text-[#ecf1e8]'
-                  : 'border-[#dad2c4] bg-[#f8f4ec] text-[#4f6658] hover:border-[#a9baa8]'
+                  ? 'border-[#2d5f48] bg-[#2d5f48] text-[#ecf1e8] shadow-sm'
+                  : 'border-[#dad2c4] bg-[#f8f4ec] text-[#4f6658] hover:border-[#a9baa8] hover:bg-[#f0eadd]'
               }`}
               type="button"
               onClick={() => setActiveSort(option.value)}

--- a/src/components/profile/ProfileInfoSection.tsx
+++ b/src/components/profile/ProfileInfoSection.tsx
@@ -15,7 +15,7 @@ function InfoField({ label, value }: { label: string; value: string }) {
       <Input
         value={value}
         readOnly
-        className="bg-brand-muted border-none text-gray-700 pointer-events-none h-10 w-full"
+        className="bg-brand-muted border-none text-foreground pointer-events-none h-10 w-full"
       />
     </div>
   );
@@ -123,7 +123,7 @@ export default function ProfileInfoSection() {
           <Button
             variant="outline"
             onClick={() => setIsEditing(true)}
-            className="flex items-center gap-1.5 text-[13px] text-brand border-gray-300 rounded-lg h-9 w-full sm:w-auto"
+            className="flex items-center gap-1.5 text-[13px] text-brand border-border rounded-lg h-9 w-full sm:w-auto"
           >
             <Edit2 className="w-3.5 h-3.5" />
             Edit Profil
@@ -177,7 +177,7 @@ export default function ProfileInfoSection() {
                 onChange={(e) =>
                   setFormData({ ...formData, name: e.target.value })
                 }
-                className="h-10 border-gray-300"
+                className="h-10 border-border"
               />
             </div>
             <div className="flex flex-col gap-2">
@@ -187,7 +187,7 @@ export default function ProfileInfoSection() {
                 onChange={(e) =>
                   setFormData({ ...formData, phoneNumber: e.target.value })
                 }
-                className="h-10 border-gray-300"
+                className="h-10 border-border"
               />
             </div>
             <div className="flex flex-col gap-2">
@@ -195,7 +195,7 @@ export default function ProfileInfoSection() {
               <Input
                 value={user?.email || ''}
                 readOnly
-                className="bg-brand-muted border-none text-gray-700 pointer-events-none h-10 w-full"
+                className="bg-brand-muted border-none text-foreground pointer-events-none h-10 w-full"
               />
             </div>
             <div className="flex flex-col gap-2">
@@ -205,7 +205,7 @@ export default function ProfileInfoSection() {
                 onChange={(e) =>
                   setFormData({ ...formData, gender: e.target.value })
                 }
-                className="flex h-10 w-full rounded-md border border-gray-300 bg-background px-3 py-2 text-sm ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
+                className="flex h-10 w-full rounded-md border border-border bg-background px-3 py-2 text-sm ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <option value="">Pilih</option>
                 <option value="male">Laki-laki</option>
@@ -221,7 +221,7 @@ export default function ProfileInfoSection() {
               onChange={(e) =>
                 setFormData({ ...formData, birthDate: e.target.value })
               }
-              className="h-10 border-gray-300 w-full md:w-[calc(50%-0.5rem)]"
+              className="h-10 border-border w-full md:w-[calc(50%-0.5rem)]"
             />
           </div>
         </div>

--- a/src/components/profile/SecuritySection.tsx
+++ b/src/components/profile/SecuritySection.tsx
@@ -40,7 +40,7 @@ function SecurityRow({
       <div className="flex items-center gap-3 w-full sm:w-auto">
         {icon}
         <div>
-          <div className="text-[13px] font-medium text-gray-700">{title}</div>
+          <div className="text-[13px] font-medium text-foreground">{title}</div>
           {subtitle && (
             <div className="text-[12px] text-amber-700">{subtitle}</div>
           )}
@@ -49,7 +49,7 @@ function SecurityRow({
       {action && (
         <Button
           variant="outline"
-          className="h-8 px-3.5 text-xs text-gray-700 w-full sm:w-auto mt-1 sm:mt-0"
+          className="h-8 px-3.5 text-xs text-foreground w-full sm:w-auto mt-1 sm:mt-0"
         >
           {action}
         </Button>
@@ -141,7 +141,7 @@ export default function SecuritySection() {
             variant="outline"
             onClick={() => setIsChangingPassword(true)}
             disabled={isOAuthOnly}
-            className="flex items-center gap-1.5 text-[13px] text-brand border-gray-300 rounded-lg h-9 w-full sm:w-auto disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex items-center gap-1.5 text-[13px] text-brand border-border rounded-lg h-9 w-full sm:w-auto disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Ubah Password
           </Button>

--- a/src/components/profile/Sidebar.tsx
+++ b/src/components/profile/Sidebar.tsx
@@ -68,7 +68,7 @@ export default function Sidebar() {
           className={`flex-auto md:flex-none flex items-center justify-center md:justify-between px-3 md:px-3.5 py-2 md:py-2.5 rounded-lg cursor-pointer text-sm transition-colors whitespace-nowrap ${
             href && pathname === href
               ? 'bg-brand-muted text-brand font-medium'
-              : 'bg-transparent text-gray-700 hover:bg-gray-100'
+              : 'bg-transparent text-foreground hover:bg-muted'
           }`}
         >
           <div className="flex items-center gap-2.5">

--- a/src/components/profile/my-order/my-order-list.tsx
+++ b/src/components/profile/my-order/my-order-list.tsx
@@ -190,15 +190,6 @@ export function MyOrderList({ activeTab, page, setPage }: MyOrderListProps) {
                 Batalkan
               </Button>
             )}
-            {order.actions.includes('Lacak Pesanan') && (
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-8 rounded-lg border-[#c4826b] text-[#c4826b] hover:bg-[#fdf6f2] hover:text-[#a06651] text-xs font-semibold px-4"
-              >
-                Lacak Pesanan
-              </Button>
-            )}
             {order.actions.includes('Detail') && (
               <Button
                 variant="outline"

--- a/src/hooks/use-order.ts
+++ b/src/hooks/use-order.ts
@@ -26,7 +26,7 @@ export interface OrderItem {
     quantity: number;
     imageURL: string | null;
   }>;
-  actions: ('Lacak Pesanan' | 'Detail')[];
+  actions: 'Detail'[];
 }
 
 export interface OrderDetail {

--- a/src/services/order.service.ts
+++ b/src/services/order.service.ts
@@ -549,10 +549,7 @@ export const orderService = {
           paymentDeadlineAt: paymentDeadlineAt?.toISOString() ?? null,
           canCancel: canCancelPendingOrder(order),
           products,
-          actions: [
-            'Detail',
-            ...(uiStatus === 'Dikirim' ? ['Lacak Pesanan'] : []),
-          ] as ('Lacak Pesanan' | 'Detail')[],
+          actions: ['Detail'] as 'Detail'[],
         };
       }),
     );

--- a/tests/api/orders/orders.route.test.ts
+++ b/tests/api/orders/orders.route.test.ts
@@ -33,7 +33,7 @@ describe('Orders API GET', { tags: ['backend'] }, () => {
             quantity: 1,
             imageURL: null,
           },
-          actions: ['Detail'] as ('Detail' | 'Lacak Pesanan')[],
+          actions: ['Detail'] as 'Detail'[],
         },
       ],
       meta: {


### PR DESCRIPTION
- normalize hardcoded gray/slate colors to semantic tokens across admin, profile, and checkout components (dark-mode safe, consistent)
- add theme-consistent hover/tap micro-interactions to landing page and encyclopedia (card lift, image zoom, arrow motion, focus rings)
- redesign encyclopedia header stats into icon cards + title accent
- fix(checkout): include imageURL in buy-now session so product image renders in order summary and payment confirmation

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.